### PR TITLE
Speed up Train Refresh Rate by Using New API Endpoint (Second Version)

### DIFF
--- a/components/Map.tsx
+++ b/components/Map.tsx
@@ -112,17 +112,15 @@ const Map = ({ serverId }: MapProps) => {
     function update() {
         getTrains()
         if (renewal == 0) {
-            console.log("Complete Renewal; code " + renewal)
             getStations()
             setRenewal(2)
         } else {
-            console.log("Position Update; code " + renewal)
             setRenewal(renewal - 1)
         }
     }
 
     useEffect(() => {
-        setTimeout(() => { update() }, 5000)
+        setTimeout(() => { update() }, 5500)
     }, [renewal]);
 
     useEffect(() => {

--- a/components/Map.tsx
+++ b/components/Map.tsx
@@ -62,7 +62,7 @@ const Map = ({ serverId }: MapProps) => {
             .then((fetchedPositionsPerTrainID) => {
                 alreadyTrains?.forEach((train) => {
                     const element = fetchedPositionsPerTrainID.data.find((fetchedTrain: any) => fetchedTrain.id === train.id);
-                    if (!element) { return train }
+                    if (!element) { return }
                     train.TrainData.Latititute = element.Latitude;
                     train.TrainData.Longitute = element.Longitude;
                     train.TrainData.Velocity = element.Velocity;
@@ -108,17 +108,16 @@ const Map = ({ serverId }: MapProps) => {
         }
     }, [trains, map, setSelectedTrain, trainId])
 
-    const [renewal, setRenewal] = useState(2);
+    const [renewal, setRenewal] = useState(0);
     function update() {
-        if (renewal == 2) {
+        getTrains()
+        if (renewal == 0) {
             console.log("Complete Renewal; code " + renewal)
             getStations()
-            getTrains()
-            setRenewal(0)
+            setRenewal(2)
         } else {
             console.log("Position Update; code " + renewal)
-            updateTrains(trains)
-            setRenewal(renewal + 1)
+            setRenewal(renewal - 1)
         }
     }
 

--- a/components/Markers/TrainMarker.tsx
+++ b/components/Markers/TrainMarker.tsx
@@ -19,6 +19,8 @@ export const TrainMarker = ({ train }: TrainMarkerProps) => {
 
     useEffect(() => {
 
+        console.log("Train No.: " + train.TrainNoLocal + " Control: " + train.TrainData.ControlledBySteamID)
+
         getData()
 
         async function getData() {

--- a/components/Markers/TrainMarker.tsx
+++ b/components/Markers/TrainMarker.tsx
@@ -19,8 +19,6 @@ export const TrainMarker = ({ train }: TrainMarkerProps) => {
 
     useEffect(() => {
 
-        console.log("Train No.: " + train.TrainNoLocal + " Control: " + train.TrainData.ControlledBySteamID)
-
         getData()
 
         async function getData() {


### PR DESCRIPTION
I've updated **Map.tsx** again to incorporate the new API endpoint. This ensures faster train position refresh rate (5500ms).

This time around, I am sure it works: I've spent 15 minutes on the map trying to spot the flicker / icon-change error; I am happy to say it has been fixed. However, please examine it thoroughly too, just to make sure, because I am unsure what exactly has caused the error in the first place. 
Additionally, please check that 5500ms are enough. If you notice the position only changing every 11000ms (2x 5500ms) please bump up the interval.