### PR TITLE
Station updates

### DIFF
--- a/components/stations.json
+++ b/components/stations.json
@@ -156,54 +156,6 @@
     "id": ""
   },
   {
-    "Name": "Dąbrowa Górnicza Pogoria",
-    "Prefix": "",
-    "DifficultyLevel": 0,
-    "MainImageURL": "",
-    "AdditionalImage1URL": "",
-    "AdditionalImage2URL": "",
-    "DispatchedBy": [],
-    "Latititude": 50.350499,
-    "Longitude": 19.240848,
-    "id": ""
-  },
-  {
-    "Name": "Dąbrowa Górnicza Gołonóg",
-    "Prefix": "",
-    "DifficultyLevel": 0,
-    "MainImageURL": "",
-    "AdditionalImage1URL": "",
-    "AdditionalImage2URL": "",
-    "DispatchedBy": [],
-    "Latititude": 50.343768,
-    "Longitude": 19.225709,
-    "id": ""
-  },
-  {
-    "Name": "Będzin Ksawera",
-    "Prefix": "",
-    "DifficultyLevel": 0,
-    "MainImageURL": "",
-    "AdditionalImage1URL": "",
-    "AdditionalImage2URL": "",
-    "DispatchedBy": [],
-    "Latititude": 50.330515,
-    "Longitude": 19.157925,
-    "id": ""
-  },
-  {
-    "Name": "Będzin Miasto",
-    "Prefix": "",
-    "DifficultyLevel": 0,
-    "MainImageURL": "",
-    "AdditionalImage1URL": "",
-    "AdditionalImage2URL": "",
-    "DispatchedBy": [],
-    "Latititude": 50.319178,
-    "Longitude": 19.135523,
-    "id": ""
-  },
-  {
     "Name": "Katowice Szopienice Południowe",
     "Prefix": "",
     "DifficultyLevel": 0,

--- a/components/stations.json
+++ b/components/stations.json
@@ -156,6 +156,18 @@
     "id": ""
   },
   {
+    "Name": "Radzice",
+    "Prefix": "",
+    "DifficultyLevel": 0,
+    "MainImageURL": "",
+    "AdditionalImage1URL": "",
+    "AdditionalImage2URL": "",
+    "DispatchedBy": [],
+    "Latititude": 51.46685425059842,
+    "Longitude": 20.39587091070566,
+    "id": ""
+  },
+  {
     "Name": "Strzałki",
     "Prefix": "",
     "DifficultyLevel": 0,

--- a/components/stations.json
+++ b/components/stations.json
@@ -144,42 +144,6 @@
     "id": ""
   },
   {
-    "Name": "Myszków Mrzygłód",
-    "Prefix": "",
-    "DifficultyLevel": 0,
-    "MainImageURL": "",
-    "AdditionalImage1URL": "",
-    "AdditionalImage2URL": "",
-    "DispatchedBy": [],
-    "Latititude": 50.543482,
-    "Longitude": 19.377319,
-    "id": ""
-  },
-  {
-    "Name": "Zawiercie Borowe Pole",
-    "Prefix": "",
-    "DifficultyLevel": 0,
-    "MainImageURL": "",
-    "AdditionalImage1URL": "",
-    "AdditionalImage2URL": "",
-    "DispatchedBy": [],
-    "Latititude": 50.511076,
-    "Longitude": 19.398674,
-    "id": ""
-  },
-  {
-    "Name": "Wiesiółka",
-    "Prefix": "",
-    "DifficultyLevel": 0,
-    "MainImageURL": "",
-    "AdditionalImage1URL": "",
-    "AdditionalImage2URL": "",
-    "DispatchedBy": [],
-    "Latititude": 50.511076,
-    "Longitude": 19.398674,
-    "id": ""
-  },
-  {
     "Name": "Przemiarki",
     "Prefix": "",
     "DifficultyLevel": 0,

--- a/components/stations.json
+++ b/components/stations.json
@@ -336,6 +336,54 @@
     "id": ""
   },
   {
+    "Name": "Kozioł",
+    "Prefix": "",
+    "DifficultyLevel": 0,
+    "MainImageURL": "",
+    "AdditionalImage1URL": "",
+    "AdditionalImage2URL": "",
+    "DispatchedBy": [],
+    "Latititude": 50.30827041951533,
+    "Longitude": 19.383104570811348,
+    "id": ""
+  },
+  {
+    "Name": "Dąbrowa Górnicza Towarowa",
+    "Prefix": "",
+    "DifficultyLevel": 0,
+    "MainImageURL": "",
+    "AdditionalImage1URL": "",
+    "AdditionalImage2URL": "",
+    "DispatchedBy": [],
+    "Latititude": 50.32932205558977,
+    "Longitude": 19.377640767189607,
+    "id": ""
+  },
+  {
+    "Name": "Dąbrowa Górnicza Strzemieszyce",
+    "Prefix": "",
+    "DifficultyLevel": 0,
+    "MainImageURL": "",
+    "AdditionalImage1URL": "",
+    "AdditionalImage2URL": "",
+    "DispatchedBy": [],
+    "Latititude": 50.31140078325932,
+    "Longitude": 19.267317086518855,
+    "id": ""
+  },
+  {
+    "Name": "Dorota",
+    "Prefix": "",
+    "DifficultyLevel": 0,
+    "MainImageURL": "",
+    "AdditionalImage1URL": "",
+    "AdditionalImage2URL": "",
+    "DispatchedBy": [],
+    "Latititude": 50.28277153042797,
+    "Longitude": 19.280647603096167,
+    "id": ""
+  },
+  {
     "Name": "Sławków",
     "Prefix": "",
     "DifficultyLevel": 0,

--- a/components/stations.json
+++ b/components/stations.json
@@ -36,15 +36,15 @@
     "id": ""
   },
   {
-    "Name": "Łazy",
+    "Name": "Łazy ŁB",
     "Prefix": "",
     "DifficultyLevel": 0,
     "MainImageURL": "",
     "AdditionalImage1URL": "",
     "AdditionalImage2URL": "",
     "DispatchedBy": [],
-    "Latititude": 50.43012201015637,
-    "Longitude": 19.391871759516924,
+    "Latititude": 50.43978712187275,
+    "Longitude": 19.40459475825095,
     "id": ""
   },
   {
@@ -120,7 +120,7 @@
     "id": ""
   },
   {
-    "Name": "Łazy Ła",
+    "Name": "Łazy ŁA",
     "Prefix": "",
     "DifficultyLevel": 0,
     "MainImageURL": "",
@@ -180,27 +180,15 @@
     "id": ""
   },
   {
-    "Name": "Chruszczobród",
+    "Name": "Przemiarki",
     "Prefix": "",
     "DifficultyLevel": 0,
     "MainImageURL": "",
     "AdditionalImage1URL": "",
     "AdditionalImage2URL": "",
     "DispatchedBy": [],
-    "Latititude": 50.400345,
-    "Longitude": 19.329007,
-    "id": ""
-  },
-  {
-    "Name": "Dąbrowa Górnicza Sikorka",
-    "Prefix": "",
-    "DifficultyLevel": 0,
-    "MainImageURL": "",
-    "AdditionalImage1URL": "",
-    "AdditionalImage2URL": "",
-    "DispatchedBy": [],
-    "Latititude": 50.388950,
-    "Longitude": 19.299095,
+    "Latititude": 50.385874,
+    "Longitude": 19.340057,
     "id": ""
   },
   {

--- a/components/stations.json
+++ b/components/stations.json
@@ -288,63 +288,27 @@
     "id": ""
   },
   {
-    "Name": "Jaktorów",
+    "Name": "Korytów",
     "Prefix": "",
     "DifficultyLevel": 0,
     "MainImageURL": "",
     "AdditionalImage1URL": "",
     "AdditionalImage2URL": "",
     "DispatchedBy": [],
-    "Latititude": 52.0868088,
-    "Longitude": 20.5520155,
+    "Latititude": 52.0200658,
+    "Longitude": 20.4954014,
     "id": ""
   },
   {
-    "Name": "Grodzisk Mazowiecki",
+    "Name": "Żyrardów",
     "Prefix": "",
     "DifficultyLevel": 0,
     "MainImageURL": "",
     "AdditionalImage1URL": "",
     "AdditionalImage2URL": "",
     "DispatchedBy": [],
-    "Latititude": 52.1101932,
-    "Longitude": 20.6231492,
-    "id": ""
-  },
-  {
-    "Name": "Milanówek",
-    "Prefix": "",
-    "DifficultyLevel": 0,
-    "MainImageURL": "",
-    "AdditionalImage1URL": "",
-    "AdditionalImage2URL": "",
-    "DispatchedBy": [],
-    "Latititude": 52.1248885,
-    "Longitude": 20.6670406,
-    "id": ""
-  },
-  {
-    "Name": "Brwinów",
-    "Prefix": "",
-    "DifficultyLevel": 0,
-    "MainImageURL": "",
-    "AdditionalImage1URL": "",
-    "AdditionalImage2URL": "",
-    "DispatchedBy": [],
-    "Latititude": 52.1417056,
-    "Longitude": 20.7185405,
-    "id": ""
-  },
-  {
-    "Name": "Parzniew",
-    "Prefix": "",
-    "DifficultyLevel": 0,
-    "MainImageURL": "",
-    "AdditionalImage1URL": "",
-    "AdditionalImage2URL": "",
-    "DispatchedBy": [],
-    "Latititude": 52.1570244,
-    "Longitude": 20.7638017,
+    "Latititude": 52.05283204,
+    "Longitude": 20.45168499,
     "id": ""
   },
   {
@@ -355,8 +319,8 @@
     "AdditionalImage1URL": "",
     "AdditionalImage2URL": "",
     "DispatchedBy": [],
-    "Latititude": 52.1681255,
-    "Longitude": 20.7978013,
+    "Latititude": 52.1666447,
+    "Longitude": 20.7947273,
     "id": ""
   },
   {

--- a/components/stations.json
+++ b/components/stations.json
@@ -7,8 +7,8 @@
     "AdditionalImage1URL": "",
     "AdditionalImage2URL": "",
     "DispatchedBy": [],
-    "Latititude": 50.257830428514104,
-    "Longitude": 19.017074474342863,
+    "Latititude": 50.256732080652974,
+    "Longitude": 19.021499279360807,
     "id": ""
   },
   {
@@ -153,18 +153,6 @@
     "DispatchedBy": [],
     "Latititude": 50.385874,
     "Longitude": 19.340057,
-    "id": ""
-  },
-  {
-    "Name": "Katowice Szopienice Południowe",
-    "Prefix": "",
-    "DifficultyLevel": 0,
-    "MainImageURL": "",
-    "AdditionalImage1URL": "",
-    "AdditionalImage2URL": "",
-    "DispatchedBy": [],
-    "Latititude": 50.258875,
-    "Longitude": 19.092237,
     "id": ""
   },
   {


### PR DESCRIPTION
I checked the playable stations for their actual neighbour stations, added a few and removed stations without dispatcher post. They are clearly recognizable by not having any switches. Those passenger train stops could be moved to a seperate filter category (bottom right corner). I removed them for now, because I think it is more helpful for dispatchers and drivers to see the real dispatch stations.

Minor detail: Łazy ŁA/ŁB/ŁC actually have capital letters at the end, but SimRail itself uses both spellings.

Sneak Peak: the line between Łazy ŁA and Dąbrowa Górnicza Wschodnia is almost finished and already has trains running on EU3.