### PR TITLE
Add tooltips and drift animation to train markers

### DIFF
--- a/components/Map.tsx
+++ b/components/Map.tsx
@@ -69,7 +69,7 @@ const Map = ({ serverId }: MapProps) => {
             // @ts-ignore
             setSelectedTrain(trains.find(train => train.id === selectedTrain.id) ?? null)
             // @ts-ignore
-            map.setView([selectedTrain?.TrainData.Latititute, selectedTrain?.TrainData.Longitute])
+            map.setView([selectedTrain?.TrainData.Latititute, selectedTrain?.TrainData.Longitute], undefined, { animate: true, duration: 5, easeLinearity: 0.5 })
         }
     }, [trains, selectedTrain, map])
 

--- a/components/Markers/TrainMarker.tsx
+++ b/components/Markers/TrainMarker.tsx
@@ -1,5 +1,6 @@
 import L from 'leaflet';
-import { Marker, Popup, useMapEvents, Tooltip } from "react-leaflet";
+import { Popup, useMapEvents, Tooltip } from "react-leaflet";
+import ReactLeafletDriftMarker from "react-leaflet-drift-marker"
 import React, { useEffect, useState } from "react";
 import { Train } from "@simrail/types";
 import { useSelectedTrain } from '../../contexts/SelectedTrainContext';
@@ -47,11 +48,12 @@ const TrainMarker = ({ train }: TrainMarkerProps) => {
 
     if (!username) return null;
 
-    return <Marker
+    return <ReactLeafletDriftMarker
         key={train.TrainNoLocal}
         icon={icon}
         position={[train.TrainData.Latititute, train.TrainData.Longitute]}
         zIndexOffset={40}
+        duration={500}
         eventHandlers={{
             mouseover: (event) => event.target.openPopup(),
             mouseout: (event) => event.target.closePopup(),
@@ -63,7 +65,7 @@ const TrainMarker = ({ train }: TrainMarkerProps) => {
             <TrainText train={train} username={username} avatar={avatar} />
         </Popup>
         <Tooltip offset={[2, -10]} direction={"top"} opacity={0.8} permanent={true}>{train.TrainNoLocal}</Tooltip>
-    </Marker>
+    </ReactLeafletDriftMarker>
 }
 
 export default React.memo(TrainMarker)

--- a/components/Markers/TrainMarker.tsx
+++ b/components/Markers/TrainMarker.tsx
@@ -1,5 +1,5 @@
 import L from 'leaflet';
-import { Marker, Popup, useMapEvents } from "react-leaflet";
+import { Marker, Popup, useMapEvents, Tooltip } from "react-leaflet";
 import React, { useEffect, useState } from "react";
 import { Train } from "@simrail/types";
 import { useSelectedTrain } from '../../contexts/SelectedTrainContext';
@@ -62,6 +62,7 @@ const TrainMarker = ({ train }: TrainMarkerProps) => {
         <Popup>
             <TrainText train={train} username={username} avatar={avatar} />
         </Popup>
+        <Tooltip offset={[2, -10]} direction={"top"} opacity={0.8} permanent={true}>{train.TrainNoLocal}</Tooltip>
     </Marker>
 }
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react-icons": "^4.7.1",
     "react-leaflet": "^4.2.0",
     "react-leaflet-custom-control": "^1.3.1",
+    "react-leaflet-drift-marker": "^4.0.0",
     "sharp": "^0.31.3",
     "typescript": "4.9.4"
   },


### PR DESCRIPTION
I think it is quite useful to have train numbers always visible. I also tried interpolating train marker positions, but the results weren't great. And just adding CSS animations was not working well with popups. The package react-leaflet-drift-marker is at least better than the current state. It does not have dependencies itself and seems to be safe. A real position interpolation would still be nice to have.