### PR TITLE
Fix: use station images from API

### DIFF
--- a/components/Markers/StationMarker.tsx
+++ b/components/Markers/StationMarker.tsx
@@ -53,7 +53,7 @@ export const StationMarker = ({ station }: StationMarkerProps) => {
         }}
     >
         <Popup>
-            <Image src={"/stations/" + station.id + '.jpg'} alt={station.Name} width={200} height={75} style={{ borderRadius: '6px' }} /><br />
+            <Image src={station.MainImageURL} alt={station.Name} width={200} height={86} style={{ borderRadius: '6px' }} /><br />
             <Space h="sm" />
             Station: {station.Name}<br />
             User: {username}<br />


### PR DESCRIPTION
Currently station images are added manually to /public/stations, but images are not displayed anymore for some reason. Simrail API now provides images for every station whereas MainImageURL seems to be most suitable and they are all of the same resolution. 

With this PR, /public/stations probably becomes obsolete.