### PR TITLE
Update next/image config version

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,7 +3,14 @@ const nextConfig = {
   reactStrictMode: true,
   output: 'standalone',
   images: {
-    domains: ['api1.aws.simrail.eu'],
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'api1.aws.simrail.eu',
+        port: '8082',
+        pathname: '/**',
+      },
+    ],
   },
 }
 


### PR DESCRIPTION
For some reason, station images are not loaded on prod.

Example HTTP 500:
https://map.simrail.app/_next/image?url=https%3A%2F%2Fapi1.aws.simrail.eu%3A8082%2FThumbnails%2FStations%2Fb1m.jpg&w=256&q=75

I can't reproduce this issue locally (either `npm run dev`, or `npm run build` and `npm run start`).

But I noticed that the config style for allowed domains for next/image changed with next.js version 12.3.0 (map-v2 uses 13.1.1). Maybe this fixes the problem.
https://nextjs.org/docs/messages/next-image-unconfigured-host