### PR TITLE
Added more train info

### DIFF
--- a/components/TrainText.tsx
+++ b/components/TrainText.tsx
@@ -10,17 +10,39 @@ type TrainTextProps = {
 
 const TrainText = ({ train, username }: TrainTextProps) => {
 
+    let trainType = train.Vehicles[0];
+    let trainAmount = 1
+    for (let i = 1; i < train.Vehicles.length; i++) {
+        if (train.Vehicles[i] === trainType) {
+            trainAmount++;
+        }
+    }
+
+    let trainAmountString = '';
+    if (trainAmount > 1) 
+        trainAmountString = `x${trainAmount}`;
+
+    let wagonsAmount = train.Vehicles.length - trainAmount;
+    let wagonsAmountString = ''
+    if (wagonsAmount > 0 && train.Vehicles[0].includes('EN57') == false) // Some EN57 show wagons = 1 one for some reason so just ignore them
+        wagonsAmountString = <>Wagons: x{wagonsAmount} <br /></>;
+
+    let distanceToSignal = (train.TrainData.DistanceToSignalInFront/1000).toFixed(1) + "km"
+    if (train.TrainData.DistanceToSignalInFront < 1000)
+        distanceToSignal = Math.round(train.TrainData.DistanceToSignalInFront) + "m"
+
     return (
         <>
             <Image src={getTrainImagePath(train)} width={"64"} height={"64"} alt={train.Vehicles[0]} /><br />
-            Locomotive: {train.Vehicles[0]}<br />
+            Type: {train.Vehicles[0]} {trainAmountString}<br />
             Train: {train.TrainName} {train.TrainNoLocal}<br />
+            {wagonsAmountString}
             User: {username}<br />
             Speed: {Math.round(train.TrainData.Velocity)} km/h<br />
             Departure: {train.StartStation}<br />
             Destination: {train.EndStation}<br />
+            Distance to signal: {distanceToSignal}<br />
         </>
-
     )
 }
 


### PR DESCRIPTION
Added more train info for the infobox.
Locomotive renamed to type as it can be a EMU and not a locomotive
If multiple locos or EMU's are coupled together it shows x[amount] after the the locomotive/type name
Shows distance to signal in km with 1 decimal until under 1km were it then shows distance in meters with no decimals