### PR TITLE
Fixed show more info icon not showing

### DIFF
--- a/components/Map.tsx
+++ b/components/Map.tsx
@@ -267,7 +267,7 @@ const Map = ({ serverId }: MapProps) => {
                         localStorage.removeItem('showSignalInfo')
                         localStorage.setItem('showSignalInfo', newShowSignalInfo.valueOf().toString())
 
-                    }} className={styles.controls}>
+                    }} className={controlTheme}>
 
                         <span className="material-symbols-outlined">
                             {showSignalInfo === true ? 'infoarrow_drop_down' : 'infoarrow_drop_up'}


### PR DESCRIPTION
This icon worked in it's branch but when multiple PR's got merged it somehow changed over to the wrong style, now fixed.