### PR TITLE
Changed around popup/infobox

### DIFF
--- a/components/TrainText.tsx
+++ b/components/TrainText.tsx
@@ -92,8 +92,6 @@ const TrainText = ({train, username}: TrainTextProps) => {
 
     // get some general information about the wagon count
     const wagonCount = wagons.length;
-    const freightWagonCount = wagons.filter((wagon) => wagon.railcar.freightTransportation).length;
-    const passengerWagonCount = wagons.filter((wagon) => wagon.railcar.passengerTransportation).length;
 
     // only the first unit is responsible for train traction at the moment, so this is just safe to assume
     // however, this might be wrong in case the first unit is not yet registered in railcars.json, so we just
@@ -120,18 +118,23 @@ const TrainText = ({train, username}: TrainTextProps) => {
         })
         .reduce((partial, current) => partial + current, 0);
 
+    // get the lowest speed of the consist
+    const minMaxSpeed = usedRailcarInfo
+        .map((info) => info.railcar.maxSpeed)
+        .reduce((minSpeed, currentSpeed) => Math.min(minSpeed, currentSpeed), Infinity);
+
     return (
         <>
             {locomotiveImages}
-            Train: {getTrainDisplayName(train.TrainName, train.TrainNoLocal)}<br/>
+            {getTrainDisplayName(train.TrainName, train.TrainNoLocal)}<br/>
+            {train.StartStation} - {train.EndStation}<br/>
             Main Unit: {tractionUnitInfo}<br/>
             {additionalUnitCount > 0 && <>Other Units: x{additionalUnitCount}<br/></>}
-            {wagonCount > 0 && <>Wagons: x{wagonCount} (P: {passengerWagonCount}, F: {freightWagonCount})<br/></>}
+            {wagonCount > 0 && <>Wagons: x{wagonCount} <br/></>}
             Length / Weight: {trainLength}m / {trainWeight}t<br/>
             User: {username}<br/>
+            Vmax: {minMaxSpeed} km/h<br/>
             Speed: {Math.round(train.TrainData.Velocity)} km/h<br/>
-            Departure: {train.StartStation}<br/>
-            Destination: {train.EndStation}<br/>
             {localStorage.getItem('showSignalInfo') === "true" && <><TrainUpcomingSignal train={train}/><br/></>}
         </>
     )


### PR DESCRIPTION
Removed "Train:" as you can tell from the train type and train number that it is infact the train part. Changed departure and Destination to one string with [place] - [place] as this is easier to read and takes up less space. Removed (P: 0, F: 0) part of wagon count as this is confusing and unnecessary. I have had friends ask me what this means and I did not myself understand it until I read the code. You can also tell if it is passenger or freight wagons from the train number aswell as the train type. There are also no freight trains pulling mixed wagons or passenger wagons as far as I know. I also added a vmax calculated from the lowest speed in the consist. The vmax is good for dispatchers using the map to choose what trains to prioritize.

Old:
![image](https://github.com/simrail/map-v2/assets/68858896/20d93b65-215f-422d-a32d-90cffac79b75)
New:
![image](https://github.com/simrail/map-v2/assets/68858896/b0aa34ff-9f24-4b04-9648-f543feebe06e)
