### PR TITLE
refactor time rendering in top navigation

### DIFF
--- a/packages/map/components/TopNavigation.tsx
+++ b/packages/map/components/TopNavigation.tsx
@@ -34,7 +34,9 @@ export const TopNavigation = ({ disableMapFeatures }: TopNavigationProps) => {
 
 	useEffect(() => {
 		if (id) {
-			const serverUtcOffHours = serverTimes.find((server) => server.Name === id)?.UTCOff;
+			const serverUtcOffHours = serverTimes.find(
+				(server) => server.Name === id,
+			)?.UTCOff;
 			if (serverUtcOffHours !== undefined) {
 				const timer = setInterval(() => {
 					// update blinking state of the colon


### PR DESCRIPTION
Refactored the time rendering in the top navigation to use the unix timestamp directly instead of modifying the hours of the date object. This also fixes the issue that the server date is not displayed based on the server time but rather based on the local time.