### PR TITLE
When you click on a station on the map, it opens its EDR.

### DIFF
--- a/packages/map/components/EDR_station.json
+++ b/packages/map/components/EDR_station.json
@@ -1,0 +1,334 @@
+{
+  "GW": {
+    "id": "GW",
+    "srName": "Góra Włodowska"
+  },
+  "PS": {
+    "id": "PS",
+    "srName": "Psary"
+  },
+  "KN": {
+    "id": "KN",
+    "srName": "Knapówka"
+  },
+  "WP": {
+    "id": "WP",
+    "srName": "Włoszczowa Północ"
+  },
+  "OZ": {
+    "id": "OZ",
+    "srName": "Olszamowice"
+  },
+  "PI": {
+    "id": "PI",
+    "srName": "Pilichowice"
+  },
+  "KZ": {
+    "id": "KZ",
+    "srName": "Katowice Zawodzie"
+  },
+  "SG": {
+    "id": "SG",
+    "srName": "Sosnowiec Główny"
+  },
+  "SG_R52": {
+    "id": "SG_R52",
+    "srName": "Sosnowiec Gł. pzs R52"
+  },
+  "SG_PO": {
+    "id": "SG_PO",
+    "srName": "Sosnowiec Południowy"
+  },
+  "SG_DK": {
+    "id": "SG_DK",
+    "srName": "Sosnowiec Dańdówka"
+  },
+  "SG_POR": {
+    "id": "SG_POR",
+    "srName": "Sosnowiec Porąbka"
+  },
+  "SG_KAZ": {
+    "id": "SG_KAZ",
+    "srName": "Sosnowiec Kazimierz"
+  },
+  "B": {
+    "id": "B",
+    "srName": "Będzin"
+  },
+  "LZ_LC": {
+    "id": "LZ_LC",
+    "srName": "Łazy Łc"
+  },
+  "LZ_LB": {
+    "id": "LZ_LB",
+    "srName": "Łazy"
+  },
+  "LZ_LA": {
+    "id": "LZ_LA",
+    "srName": "Łazy Ła"
+  },
+  "OP_PO": {
+    "id": "OP_PO",
+    "srName": "Opoczno Południe"
+  },
+  "MY": {
+    "id": "MY",
+    "srName": "Myszków"
+  },
+  "MY_MR": {
+    "id": "MY_MR",
+    "srName": "Myszków Mrzygłód"
+  },
+  "ZA_BO_PO": {
+    "id": "ZA_BO_PO",
+    "srName": "Zawiercie Borowe Pole"
+  },
+  "ZA": {
+    "id": "ZA",
+    "srName": "Zawiercie"
+  },
+  "WI": {
+    "id": "WI",
+    "srName": "Wiesiółka"
+  },
+  "CZ": {
+    "id": "CZ",
+    "srName": "Chruszczobród"
+  },
+  "DG": {
+    "id": "DG",
+    "srName": "Dąbrowa Górnicza"
+  },
+  "DG_SI": {
+    "id": "DG_SI",
+    "srName": "Dąbrowa Górnicza Sikorka"
+  },
+  "DG_ZA": {
+    "id": "DG_ZA",
+    "srName": "Dąbrowa Górnicza Ząbkowice"
+  },
+  "DG_DZA": {
+    "id": "DG_DZA",
+    "srName": "Dąbrowa Górnicza Ząbkowice DZA"
+  },
+  "DG_DZA_R47": {
+    "id": "DG_DZA_R47",
+    "srName": "Dąbrowa Górn. Ząbkowice DZA R.4/7"
+  },
+  "DG_PO": {
+    "id": "DG_PO",
+    "srName": "Dąbrowa Górnicza Pogoria"
+  },
+  "DG_GO": {
+    "id": "DG_GO",
+    "srName": "Dąbrowa Górnicza Gołonóg"
+  },
+  "DG_WZ": {
+    "id": "DG_WZ",
+    "srName": "Dąbrowa Górnicza Wschodnia"
+  },
+  "DOR": {
+    "id": "DOR",
+    "srName": "Dorota"
+  },
+  "DG_ST": {
+    "id": "DG_ST",
+    "srName": "Dąbrowa Górnicza Strzemieszyce"
+  },
+  "BZ_KS": {
+    "id": "BZ_KS",
+    "srName": "Będzin Ksawera"
+  },
+  "BZ_MI": {
+    "id": "BZ_MI",
+    "srName": "Będzin Miasto"
+  },
+  "KSP": {
+    "id": "KSP",
+    "srName": "Katowice Szopienice Południowe"
+  },
+  "KO": {
+    "id": "KO",
+    "srName": "Katowice"
+  },
+  "CZ_R19": {
+    "id": "CZ_R19",
+    "srName": "Czarnca R19"
+  },
+  "STZ": {
+    "id": "STZ",
+    "srName": "Starzyny"
+  },
+  "IDZ": {
+    "id": "IDZ",
+    "srName": "Idzikowice"
+  },
+  "ST": {
+    "id": "ST",
+    "srName": "Strzałki"
+  },
+  "BR": {
+    "id": "BR",
+    "srName": "Biała Rawska"
+  },
+  "SZE": {
+    "id": "SZE",
+    "srName": "Szeligi"
+  },
+  "JKT": {
+    "id": "JKT",
+    "srName": "Jaktorów"
+  },
+  "GRO_MAZ": {
+    "id": "GRO_MAZ",
+    "srName": "Grodzisk Mazowiecki"
+  },
+  "MIL": {
+    "id": "MIL",
+    "srName": "Milanówek"
+  },
+  "BRW": {
+    "id": "BRW",
+    "srName": "Brwinów"
+  },
+  "PARZ": {
+    "id": "PARZ",
+    "srName": "Parzniew"
+  },
+  "KOR": {
+    "id": "KOR",
+    "srName": "Korytów"
+  },
+  "PRSZ": {
+    "id": "PRSZ",
+    "srName": "Pruszków"
+  },
+  "PIA": {
+    "id": "PIA",
+    "srName": "Piastów"
+  },
+  "WUN": {
+    "id": "WUN",
+    "srName": "Warszawa Ursus-Niedźwiadek"
+  },
+  "WW": {
+    "id": "WW",
+    "srName": "Warszawa Włochy"
+  },
+  "WZ": {
+    "id": "WZ",
+    "srName": "Warszawa Zachodnia"
+  },
+  "WC": {
+    "id": "WC",
+    "srName": "Warszawa Centralna"
+  },
+  "SLK": {
+    "id": "SLK",
+    "srName": "Sławków"
+  },
+  "BP": {
+    "id": "BP",
+    "srName": "Bukowno Przymiarki"
+  },
+  "BK": {
+    "id": "BK",
+    "srName": "Bukowno"
+  },
+  "OK": {
+    "id": "OK",
+    "srName": "Olkusz"
+  },
+  "JO": {
+    "id": "JO",
+    "srName": "Jaroszowiec Olkuski"
+  },
+  "CO": {
+    "id": "CO",
+    "srName": "Chrząstowice Olkuskie"
+  },
+  "WB": {
+    "id": "WB",
+    "srName": "Wolbrom"
+  },
+  "JZ": {
+    "id": "JZ",
+    "srName": "Jeżówka"
+  },
+  "GJ": {
+    "id": "GJ",
+    "srName": "Gajówka"
+  },
+  "CH": {
+    "id": "CH",
+    "srName": "Charsznica"
+  },
+  "TN": {
+    "id": "TN",
+    "srName": "Tunel"
+  },
+  "KOZ": {
+    "id": "KOZ",
+    "srName": "Kozłów"
+  },
+  "KLI": {
+    "id": "KLI",
+    "srName": "Klimontów"
+  },
+  "SDZ": {
+    "id": "SDZ",
+    "srName": "Sędziszów"
+  },
+  "R19_WP14": {
+    "id": "R19_WP14",
+    "srName": "Line R19"
+  },
+  "RDZ_P31": {
+    "id": "RDZ_P31",
+    "srName": "Radzice PZS R31"
+  },
+  "RDZ_R12": {
+    "id": "RDZ_R12",
+    "srName": "Radzice R12"
+  },
+  "ZEL_R6": {
+    "id": "ZEL_R6",
+    "srName": "Żelisławice R.6"
+  },
+  "ZYR": {
+    "id": "ZYR",
+    "srName": "Żyrardów"
+  },
+  "PRZ": {
+    "id": "PRZ",
+    "srName": "Przemiarki"
+  },
+  "DG_T_R5": {
+    "id": "DG_T_R5",
+    "srName": "Dąbrowa Górnicza Towarowa DTA R5"
+  },
+  "KOZI": {
+    "id": "KOZI",
+    "srName": "Kozioł"
+  },
+  "KOZI_R12": {
+    "id": "KOZI_R12",
+    "srName": "Kozioł R12"
+  },
+  "JU": {
+    "id": "JU",
+    "srName": "Juliusz"
+  },
+  "SZA": {
+    "id": "SZA",
+    "srName": "Szabelnia"
+  },
+  "SM": {
+    "id": "SM",
+    "srName": "Sosnowiec Maczki"
+  },
+  "DGHK": {
+    "id": "DGHK",
+    "srName": "Dąbrowa Górnicza Huta Katowice"
+  }
+}

--- a/packages/map/components/EDR_station.json
+++ b/packages/map/components/EDR_station.json
@@ -1,334 +1,334 @@
 {
-  "GW": {
-    "id": "GW",
-    "srName": "Góra Włodowska"
-  },
-  "PS": {
-    "id": "PS",
-    "srName": "Psary"
-  },
-  "KN": {
-    "id": "KN",
-    "srName": "Knapówka"
-  },
-  "WP": {
-    "id": "WP",
-    "srName": "Włoszczowa Północ"
-  },
-  "OZ": {
-    "id": "OZ",
-    "srName": "Olszamowice"
-  },
-  "PI": {
-    "id": "PI",
-    "srName": "Pilichowice"
-  },
-  "KZ": {
-    "id": "KZ",
-    "srName": "Katowice Zawodzie"
-  },
-  "SG": {
-    "id": "SG",
-    "srName": "Sosnowiec Główny"
-  },
-  "SG_R52": {
-    "id": "SG_R52",
-    "srName": "Sosnowiec Gł. pzs R52"
-  },
-  "SG_PO": {
-    "id": "SG_PO",
-    "srName": "Sosnowiec Południowy"
-  },
-  "SG_DK": {
-    "id": "SG_DK",
-    "srName": "Sosnowiec Dańdówka"
-  },
-  "SG_POR": {
-    "id": "SG_POR",
-    "srName": "Sosnowiec Porąbka"
-  },
-  "SG_KAZ": {
-    "id": "SG_KAZ",
-    "srName": "Sosnowiec Kazimierz"
-  },
-  "B": {
-    "id": "B",
-    "srName": "Będzin"
-  },
-  "LZ_LC": {
-    "id": "LZ_LC",
-    "srName": "Łazy Łc"
-  },
-  "LZ_LB": {
-    "id": "LZ_LB",
-    "srName": "Łazy"
-  },
-  "LZ_LA": {
-    "id": "LZ_LA",
-    "srName": "Łazy Ła"
-  },
-  "OP_PO": {
-    "id": "OP_PO",
-    "srName": "Opoczno Południe"
-  },
-  "MY": {
-    "id": "MY",
-    "srName": "Myszków"
-  },
-  "MY_MR": {
-    "id": "MY_MR",
-    "srName": "Myszków Mrzygłód"
-  },
-  "ZA_BO_PO": {
-    "id": "ZA_BO_PO",
-    "srName": "Zawiercie Borowe Pole"
-  },
-  "ZA": {
-    "id": "ZA",
-    "srName": "Zawiercie"
-  },
-  "WI": {
-    "id": "WI",
-    "srName": "Wiesiółka"
-  },
-  "CZ": {
-    "id": "CZ",
-    "srName": "Chruszczobród"
-  },
-  "DG": {
-    "id": "DG",
-    "srName": "Dąbrowa Górnicza"
-  },
-  "DG_SI": {
-    "id": "DG_SI",
-    "srName": "Dąbrowa Górnicza Sikorka"
-  },
-  "DG_ZA": {
-    "id": "DG_ZA",
-    "srName": "Dąbrowa Górnicza Ząbkowice"
-  },
-  "DG_DZA": {
-    "id": "DG_DZA",
-    "srName": "Dąbrowa Górnicza Ząbkowice DZA"
-  },
-  "DG_DZA_R47": {
-    "id": "DG_DZA_R47",
-    "srName": "Dąbrowa Górn. Ząbkowice DZA R.4/7"
-  },
-  "DG_PO": {
-    "id": "DG_PO",
-    "srName": "Dąbrowa Górnicza Pogoria"
-  },
-  "DG_GO": {
-    "id": "DG_GO",
-    "srName": "Dąbrowa Górnicza Gołonóg"
-  },
-  "DG_WZ": {
-    "id": "DG_WZ",
-    "srName": "Dąbrowa Górnicza Wschodnia"
-  },
-  "DOR": {
-    "id": "DOR",
-    "srName": "Dorota"
-  },
-  "DG_ST": {
-    "id": "DG_ST",
-    "srName": "Dąbrowa Górnicza Strzemieszyce"
-  },
-  "BZ_KS": {
-    "id": "BZ_KS",
-    "srName": "Będzin Ksawera"
-  },
-  "BZ_MI": {
-    "id": "BZ_MI",
-    "srName": "Będzin Miasto"
-  },
-  "KSP": {
-    "id": "KSP",
-    "srName": "Katowice Szopienice Południowe"
-  },
-  "KO": {
-    "id": "KO",
-    "srName": "Katowice"
-  },
-  "CZ_R19": {
-    "id": "CZ_R19",
-    "srName": "Czarnca R19"
-  },
-  "STZ": {
-    "id": "STZ",
-    "srName": "Starzyny"
-  },
-  "IDZ": {
-    "id": "IDZ",
-    "srName": "Idzikowice"
-  },
-  "ST": {
-    "id": "ST",
-    "srName": "Strzałki"
-  },
-  "BR": {
-    "id": "BR",
-    "srName": "Biała Rawska"
-  },
-  "SZE": {
-    "id": "SZE",
-    "srName": "Szeligi"
-  },
-  "JKT": {
-    "id": "JKT",
-    "srName": "Jaktorów"
-  },
-  "GRO_MAZ": {
-    "id": "GRO_MAZ",
-    "srName": "Grodzisk Mazowiecki"
-  },
-  "MIL": {
-    "id": "MIL",
-    "srName": "Milanówek"
-  },
-  "BRW": {
-    "id": "BRW",
-    "srName": "Brwinów"
-  },
-  "PARZ": {
-    "id": "PARZ",
-    "srName": "Parzniew"
-  },
-  "KOR": {
-    "id": "KOR",
-    "srName": "Korytów"
-  },
-  "PRSZ": {
-    "id": "PRSZ",
-    "srName": "Pruszków"
-  },
-  "PIA": {
-    "id": "PIA",
-    "srName": "Piastów"
-  },
-  "WUN": {
-    "id": "WUN",
-    "srName": "Warszawa Ursus-Niedźwiadek"
-  },
-  "WW": {
-    "id": "WW",
-    "srName": "Warszawa Włochy"
-  },
-  "WZ": {
-    "id": "WZ",
-    "srName": "Warszawa Zachodnia"
-  },
-  "WC": {
-    "id": "WC",
-    "srName": "Warszawa Centralna"
-  },
-  "SLK": {
-    "id": "SLK",
-    "srName": "Sławków"
-  },
-  "BP": {
-    "id": "BP",
-    "srName": "Bukowno Przymiarki"
-  },
-  "BK": {
-    "id": "BK",
-    "srName": "Bukowno"
-  },
-  "OK": {
-    "id": "OK",
-    "srName": "Olkusz"
-  },
-  "JO": {
-    "id": "JO",
-    "srName": "Jaroszowiec Olkuski"
-  },
-  "CO": {
-    "id": "CO",
-    "srName": "Chrząstowice Olkuskie"
-  },
-  "WB": {
-    "id": "WB",
-    "srName": "Wolbrom"
-  },
-  "JZ": {
-    "id": "JZ",
-    "srName": "Jeżówka"
-  },
-  "GJ": {
-    "id": "GJ",
-    "srName": "Gajówka"
-  },
-  "CH": {
-    "id": "CH",
-    "srName": "Charsznica"
-  },
-  "TN": {
-    "id": "TN",
-    "srName": "Tunel"
-  },
-  "KOZ": {
-    "id": "KOZ",
-    "srName": "Kozłów"
-  },
-  "KLI": {
-    "id": "KLI",
-    "srName": "Klimontów"
-  },
-  "SDZ": {
-    "id": "SDZ",
-    "srName": "Sędziszów"
-  },
-  "R19_WP14": {
-    "id": "R19_WP14",
-    "srName": "Line R19"
-  },
-  "RDZ_P31": {
-    "id": "RDZ_P31",
-    "srName": "Radzice PZS R31"
-  },
-  "RDZ_R12": {
-    "id": "RDZ_R12",
-    "srName": "Radzice R12"
-  },
-  "ZEL_R6": {
-    "id": "ZEL_R6",
-    "srName": "Żelisławice R.6"
-  },
-  "ZYR": {
-    "id": "ZYR",
-    "srName": "Żyrardów"
-  },
-  "PRZ": {
-    "id": "PRZ",
-    "srName": "Przemiarki"
-  },
-  "DG_T_R5": {
-    "id": "DG_T_R5",
-    "srName": "Dąbrowa Górnicza Towarowa DTA R5"
-  },
-  "KOZI": {
-    "id": "KOZI",
-    "srName": "Kozioł"
-  },
-  "KOZI_R12": {
-    "id": "KOZI_R12",
-    "srName": "Kozioł R12"
-  },
-  "JU": {
-    "id": "JU",
-    "srName": "Juliusz"
-  },
-  "SZA": {
-    "id": "SZA",
-    "srName": "Szabelnia"
-  },
-  "SM": {
-    "id": "SM",
-    "srName": "Sosnowiec Maczki"
-  },
-  "DGHK": {
-    "id": "DGHK",
-    "srName": "Dąbrowa Górnicza Huta Katowice"
-  }
+	"GW": {
+		"id": "GW",
+		"srName": "Góra Włodowska"
+	},
+	"PS": {
+		"id": "PS",
+		"srName": "Psary"
+	},
+	"KN": {
+		"id": "KN",
+		"srName": "Knapówka"
+	},
+	"WP": {
+		"id": "WP",
+		"srName": "Włoszczowa Północ"
+	},
+	"OZ": {
+		"id": "OZ",
+		"srName": "Olszamowice"
+	},
+	"PI": {
+		"id": "PI",
+		"srName": "Pilichowice"
+	},
+	"KZ": {
+		"id": "KZ",
+		"srName": "Katowice Zawodzie"
+	},
+	"SG": {
+		"id": "SG",
+		"srName": "Sosnowiec Główny"
+	},
+	"SG_R52": {
+		"id": "SG_R52",
+		"srName": "Sosnowiec Gł. pzs R52"
+	},
+	"SG_PO": {
+		"id": "SG_PO",
+		"srName": "Sosnowiec Południowy"
+	},
+	"SG_DK": {
+		"id": "SG_DK",
+		"srName": "Sosnowiec Dańdówka"
+	},
+	"SG_POR": {
+		"id": "SG_POR",
+		"srName": "Sosnowiec Porąbka"
+	},
+	"SG_KAZ": {
+		"id": "SG_KAZ",
+		"srName": "Sosnowiec Kazimierz"
+	},
+	"B": {
+		"id": "B",
+		"srName": "Będzin"
+	},
+	"LZ_LC": {
+		"id": "LZ_LC",
+		"srName": "Łazy Łc"
+	},
+	"LZ_LB": {
+		"id": "LZ_LB",
+		"srName": "Łazy"
+	},
+	"LZ_LA": {
+		"id": "LZ_LA",
+		"srName": "Łazy Ła"
+	},
+	"OP_PO": {
+		"id": "OP_PO",
+		"srName": "Opoczno Południe"
+	},
+	"MY": {
+		"id": "MY",
+		"srName": "Myszków"
+	},
+	"MY_MR": {
+		"id": "MY_MR",
+		"srName": "Myszków Mrzygłód"
+	},
+	"ZA_BO_PO": {
+		"id": "ZA_BO_PO",
+		"srName": "Zawiercie Borowe Pole"
+	},
+	"ZA": {
+		"id": "ZA",
+		"srName": "Zawiercie"
+	},
+	"WI": {
+		"id": "WI",
+		"srName": "Wiesiółka"
+	},
+	"CZ": {
+		"id": "CZ",
+		"srName": "Chruszczobród"
+	},
+	"DG": {
+		"id": "DG",
+		"srName": "Dąbrowa Górnicza"
+	},
+	"DG_SI": {
+		"id": "DG_SI",
+		"srName": "Dąbrowa Górnicza Sikorka"
+	},
+	"DG_ZA": {
+		"id": "DG_ZA",
+		"srName": "Dąbrowa Górnicza Ząbkowice"
+	},
+	"DG_DZA": {
+		"id": "DG_DZA",
+		"srName": "Dąbrowa Górnicza Ząbkowice DZA"
+	},
+	"DG_DZA_R47": {
+		"id": "DG_DZA_R47",
+		"srName": "Dąbrowa Górn. Ząbkowice DZA R.4/7"
+	},
+	"DG_PO": {
+		"id": "DG_PO",
+		"srName": "Dąbrowa Górnicza Pogoria"
+	},
+	"DG_GO": {
+		"id": "DG_GO",
+		"srName": "Dąbrowa Górnicza Gołonóg"
+	},
+	"DG_WZ": {
+		"id": "DG_WZ",
+		"srName": "Dąbrowa Górnicza Wschodnia"
+	},
+	"DOR": {
+		"id": "DOR",
+		"srName": "Dorota"
+	},
+	"DG_ST": {
+		"id": "DG_ST",
+		"srName": "Dąbrowa Górnicza Strzemieszyce"
+	},
+	"BZ_KS": {
+		"id": "BZ_KS",
+		"srName": "Będzin Ksawera"
+	},
+	"BZ_MI": {
+		"id": "BZ_MI",
+		"srName": "Będzin Miasto"
+	},
+	"KSP": {
+		"id": "KSP",
+		"srName": "Katowice Szopienice Południowe"
+	},
+	"KO": {
+		"id": "KO",
+		"srName": "Katowice"
+	},
+	"CZ_R19": {
+		"id": "CZ_R19",
+		"srName": "Czarnca R19"
+	},
+	"STZ": {
+		"id": "STZ",
+		"srName": "Starzyny"
+	},
+	"IDZ": {
+		"id": "IDZ",
+		"srName": "Idzikowice"
+	},
+	"ST": {
+		"id": "ST",
+		"srName": "Strzałki"
+	},
+	"BR": {
+		"id": "BR",
+		"srName": "Biała Rawska"
+	},
+	"SZE": {
+		"id": "SZE",
+		"srName": "Szeligi"
+	},
+	"JKT": {
+		"id": "JKT",
+		"srName": "Jaktorów"
+	},
+	"GRO_MAZ": {
+		"id": "GRO_MAZ",
+		"srName": "Grodzisk Mazowiecki"
+	},
+	"MIL": {
+		"id": "MIL",
+		"srName": "Milanówek"
+	},
+	"BRW": {
+		"id": "BRW",
+		"srName": "Brwinów"
+	},
+	"PARZ": {
+		"id": "PARZ",
+		"srName": "Parzniew"
+	},
+	"KOR": {
+		"id": "KOR",
+		"srName": "Korytów"
+	},
+	"PRSZ": {
+		"id": "PRSZ",
+		"srName": "Pruszków"
+	},
+	"PIA": {
+		"id": "PIA",
+		"srName": "Piastów"
+	},
+	"WUN": {
+		"id": "WUN",
+		"srName": "Warszawa Ursus-Niedźwiadek"
+	},
+	"WW": {
+		"id": "WW",
+		"srName": "Warszawa Włochy"
+	},
+	"WZ": {
+		"id": "WZ",
+		"srName": "Warszawa Zachodnia"
+	},
+	"WC": {
+		"id": "WC",
+		"srName": "Warszawa Centralna"
+	},
+	"SLK": {
+		"id": "SLK",
+		"srName": "Sławków"
+	},
+	"BP": {
+		"id": "BP",
+		"srName": "Bukowno Przymiarki"
+	},
+	"BK": {
+		"id": "BK",
+		"srName": "Bukowno"
+	},
+	"OK": {
+		"id": "OK",
+		"srName": "Olkusz"
+	},
+	"JO": {
+		"id": "JO",
+		"srName": "Jaroszowiec Olkuski"
+	},
+	"CO": {
+		"id": "CO",
+		"srName": "Chrząstowice Olkuskie"
+	},
+	"WB": {
+		"id": "WB",
+		"srName": "Wolbrom"
+	},
+	"JZ": {
+		"id": "JZ",
+		"srName": "Jeżówka"
+	},
+	"GJ": {
+		"id": "GJ",
+		"srName": "Gajówka"
+	},
+	"CH": {
+		"id": "CH",
+		"srName": "Charsznica"
+	},
+	"TN": {
+		"id": "TN",
+		"srName": "Tunel"
+	},
+	"KOZ": {
+		"id": "KOZ",
+		"srName": "Kozłów"
+	},
+	"KLI": {
+		"id": "KLI",
+		"srName": "Klimontów"
+	},
+	"SDZ": {
+		"id": "SDZ",
+		"srName": "Sędziszów"
+	},
+	"R19_WP14": {
+		"id": "R19_WP14",
+		"srName": "Line R19"
+	},
+	"RDZ_P31": {
+		"id": "RDZ_P31",
+		"srName": "Radzice PZS R31"
+	},
+	"RDZ_R12": {
+		"id": "RDZ_R12",
+		"srName": "Radzice R12"
+	},
+	"ZEL_R6": {
+		"id": "ZEL_R6",
+		"srName": "Żelisławice R.6"
+	},
+	"ZYR": {
+		"id": "ZYR",
+		"srName": "Żyrardów"
+	},
+	"PRZ": {
+		"id": "PRZ",
+		"srName": "Przemiarki"
+	},
+	"DG_T_R5": {
+		"id": "DG_T_R5",
+		"srName": "Dąbrowa Górnicza Towarowa DTA R5"
+	},
+	"KOZI": {
+		"id": "KOZI",
+		"srName": "Kozioł"
+	},
+	"KOZI_R12": {
+		"id": "KOZI_R12",
+		"srName": "Kozioł R12"
+	},
+	"JU": {
+		"id": "JU",
+		"srName": "Juliusz"
+	},
+	"SZA": {
+		"id": "SZA",
+		"srName": "Szabelnia"
+	},
+	"SM": {
+		"id": "SM",
+		"srName": "Sosnowiec Maczki"
+	},
+	"DGHK": {
+		"id": "DGHK",
+		"srName": "Dąbrowa Górnicza Huta Katowice"
+	}
 }

--- a/packages/map/components/Markers/StationMarker.tsx
+++ b/packages/map/components/Markers/StationMarker.tsx
@@ -1,7 +1,7 @@
 import { Space, useMantineColorScheme } from "@mantine/core";
 import type { Station } from "@simrail/types";
 import L from "leaflet";
-import { useRouter, usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { Marker, Popup, Tooltip } from "react-leaflet";
 import type { ProfileResponse } from "types/SteamProfile";
@@ -15,8 +15,8 @@ export const StationMarker = ({ station }: StationMarkerProps) => {
 	const [avatar, setAvatar] = useState<string | null>(null);
 	const [username, setUsername] = useState<string | null>(null);
 
-	const router = useRouter()
-	const pathname = usePathname()
+	const router = useRouter();
+	const pathname = usePathname();
 
 	useEffect(() => {
 		async function getData() {
@@ -64,27 +64,27 @@ export const StationMarker = ({ station }: StationMarkerProps) => {
 				mouseover: (event) => event.target.openPopup(),
 				mouseout: (event) => event.target.closePopup(),
 				click: () => {
-          // Find the corresponding station in the JSON file
-          const stationEntry = Object.values(stationsList).find(
-            (entry) => entry.srName === station.Name
-          );
+					// Find the corresponding station in the JSON file
+					const stationEntry = Object.values(stationsList).find(
+						(entry) => entry.srName === station.Name,
+					);
 
-          if (stationEntry) {
-            router.push(
-              `https://edr.simrail.app/${pathname.split("/")[2]}/station/${
-                stationEntry.id
-              }`
-            );
-          } else {
-            // Fallback to old behavior if station not found
-            router.push(
-              `https://edr.simrail.app/${
-                pathname.split("/")[2]
-              }/station/${station.Prefix.toUpperCase()}`
-            );
-          }
-        }
-}}
+					if (stationEntry) {
+						router.push(
+							`https://edr.simrail.app/${pathname.split("/")[2]}/station/${
+								stationEntry.id
+							}`,
+						);
+					} else {
+						// Fallback to old behavior if station not found
+						router.push(
+							`https://edr.simrail.app/${
+								pathname.split("/")[2]
+							}/station/${station.Prefix.toUpperCase()}`,
+						);
+					}
+				},
+			}}
 		>
 			<Popup>
 				<img

--- a/packages/map/components/Markers/StationMarker.tsx
+++ b/packages/map/components/Markers/StationMarker.tsx
@@ -5,6 +5,7 @@ import { useRouter, usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
 import { Marker, Popup, Tooltip } from "react-leaflet";
 import type { ProfileResponse } from "types/SteamProfile";
+import stationsList from "../EDR_station.json";
 
 type StationMarkerProps = {
 	station: Station;
@@ -62,9 +63,20 @@ export const StationMarker = ({ station }: StationMarkerProps) => {
 			eventHandlers={{
 				mouseover: (event) => event.target.openPopup(),
 				mouseout: (event) => event.target.closePopup(),
-				click: () => router.push(`https://edr.simrail.app/${pathname.split('/')[2]}/station/${station.Prefix.toUpperCase()}`),
-				// click: () => console.log(pathname.split('/')[2])
-			}}
+				click: () => {
+        // Chercher la station correspondante dans le fichier JSON
+        const stationEntry = Object.values(stationsList).find(
+            entry => entry.srName === station.Name
+        );
+        
+        if (stationEntry) {
+            router.push(`https://edr.simrail.app/${pathname.split('/')[2]}/station/${stationEntry.id}`);
+        } else {
+            // Fallback sur l'ancien comportement si la station n'est pas trouvée
+            router.push(`https://edr.simrail.app/${pathname.split('/')[2]}/station/${station.Prefix.toUpperCase()}`);
+        }
+    }
+}}
 		>
 			<Popup>
 				<img

--- a/packages/map/components/Markers/StationMarker.tsx
+++ b/packages/map/components/Markers/StationMarker.tsx
@@ -64,18 +64,26 @@ export const StationMarker = ({ station }: StationMarkerProps) => {
 				mouseover: (event) => event.target.openPopup(),
 				mouseout: (event) => event.target.closePopup(),
 				click: () => {
-        // Chercher la station correspondante dans le fichier JSON
-        const stationEntry = Object.values(stationsList).find(
-            entry => entry.srName === station.Name
-        );
-        
-        if (stationEntry) {
-            router.push(`https://edr.simrail.app/${pathname.split('/')[2]}/station/${stationEntry.id}`);
-        } else {
-            // Fallback sur l'ancien comportement si la station n'est pas trouvée
-            router.push(`https://edr.simrail.app/${pathname.split('/')[2]}/station/${station.Prefix.toUpperCase()}`);
+          // Find the corresponding station in the JSON file
+          const stationEntry = Object.values(stationsList).find(
+            (entry) => entry.srName === station.Name
+          );
+
+          if (stationEntry) {
+            router.push(
+              `https://edr.simrail.app/${pathname.split("/")[2]}/station/${
+                stationEntry.id
+              }`
+            );
+          } else {
+            // Fallback to old behavior if station not found
+            router.push(
+              `https://edr.simrail.app/${
+                pathname.split("/")[2]
+              }/station/${station.Prefix.toUpperCase()}`
+            );
+          }
         }
-    }
 }}
 		>
 			<Popup>

--- a/packages/map/components/Markers/StationMarker.tsx
+++ b/packages/map/components/Markers/StationMarker.tsx
@@ -1,5 +1,5 @@
 import { Space, useMantineColorScheme } from "@mantine/core";
-import type { Station, Server } from "@simrail/types";
+import type { Station } from "@simrail/types";
 import L from "leaflet";
 import { useRouter, usePathname } from "next/navigation";
 import { useEffect, useState } from "react";

--- a/packages/map/components/Markers/StationMarker.tsx
+++ b/packages/map/components/Markers/StationMarker.tsx
@@ -1,6 +1,7 @@
 import { Space, useMantineColorScheme } from "@mantine/core";
-import type { Station } from "@simrail/types";
+import type { Station, Server } from "@simrail/types";
 import L from "leaflet";
+import { useRouter, usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
 import { Marker, Popup, Tooltip } from "react-leaflet";
 import type { ProfileResponse } from "types/SteamProfile";
@@ -12,6 +13,9 @@ type StationMarkerProps = {
 export const StationMarker = ({ station }: StationMarkerProps) => {
 	const [avatar, setAvatar] = useState<string | null>(null);
 	const [username, setUsername] = useState<string | null>(null);
+
+	const router = useRouter()
+	const pathname = usePathname()
 
 	useEffect(() => {
 		async function getData() {
@@ -58,6 +62,8 @@ export const StationMarker = ({ station }: StationMarkerProps) => {
 			eventHandlers={{
 				mouseover: (event) => event.target.openPopup(),
 				mouseout: (event) => event.target.closePopup(),
+				click: () => router.push(`https://edr.simrail.app/${pathname.split('/')[2]}/station/${station.Prefix.toUpperCase()}`),
+				// click: () => console.log(pathname.split('/')[2])
 			}}
 		>
 			<Popup>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ importers:
   .:
     dependencies:
       '@simrail/types':
-        specifier: ^0.0.3
-        version: 0.0.3
+        specifier: ^0.0.4
+        version: 0.0.4
       '@types/node':
         specifier: ^20.14.12
         version: 20.14.12
@@ -132,8 +132,8 @@ importers:
         specifier: ^14.2.5
         version: 14.2.5(next@14.2.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@simrail/types':
-        specifier: ^0.0.3
-        version: 0.0.3
+        specifier: ^0.0.4
+        version: 0.0.4
       '@types/node':
         specifier: 20.14.12
         version: 20.14.12
@@ -656,8 +656,8 @@ packages:
   '@rushstack/eslint-patch@1.10.3':
     resolution: {integrity: sha512-qC/xYId4NMebE6w/V33Fh9gWxLgURiNYgVNObbJl2LZv0GUUItCcCqC5axQSwRaAgaxl2mELq1rMzlswaQ0Zxg==}
 
-  '@simrail/types@0.0.3':
-    resolution: {integrity: sha512-plggEF+8TWTBWsAT0tt6F/ECwNKNje82YvXg177mU6VrNk8pQuSKNPv1eUR8OZQLE4qvvA5fHhoBytGKybKKDA==}
+  '@simrail/types@0.0.4':
+    resolution: {integrity: sha512-AknM5FP+crERb3m/YtZqCgdFbrwUEwYB4BXfv1z+b7CVSrRsidAnaMIJZw/MhmsGxAmNIqQK7RPhDEx8qNzblA==}
 
   '@swc/core-darwin-arm64@1.6.13':
     resolution: {integrity: sha512-SOF4buAis72K22BGJ3N8y88mLNfxLNprTuJUpzikyMGrvkuBFNcxYtMhmomO0XHsgLDzOJ+hWzcgjRNzjMsUcQ==}
@@ -2789,7 +2789,7 @@ snapshots:
 
   '@rushstack/eslint-patch@1.10.3': {}
 
-  '@simrail/types@0.0.3': {}
+  '@simrail/types@0.0.4': {}
 
   '@swc/core-darwin-arm64@1.6.13':
     optional: true


### PR DESCRIPTION
Hello everyone!

Today, I'm adding a new feature to the map in relation to stations.
In fact, the stations on the map are present, but don't necessarily have a functionality specific to these markers.
That's why I want these markers to have their own functionality.
To do this, I propose that when you click on any station marker, it opens its EDR. (The EDR site in question: https://edr.simrail.app/fr1)
This means that when you want to be a dispatcher at a station, all you have to do is click, and you're on the EDR for that station. So you can properly dispatch the trains that will be passing through it.
This is much more practical for people who want to be dispatchers and often use the site.
Of course, if the user changes server, the script will make sure it knows which server he's on, so that it has the right station and the right server for dispatching trains.

Here's a demo and tell me what you think:
![opera_VpRMIkLHMT](https://github.com/user-attachments/assets/5edf810f-4822-45a0-a421-8e7955896b86)

![opera_FjO1M1fVLu](https://github.com/user-attachments/assets/fc389f69-76f0-405e-b9d9-a6687bfb4ca5)
