### PR TITLE
update for server renames, improve server time handling

### DIFF
--- a/packages/map/components/TopNavigation.tsx
+++ b/packages/map/components/TopNavigation.tsx
@@ -34,17 +34,17 @@ export const TopNavigation = ({ disableMapFeatures }: TopNavigationProps) => {
 
 	useEffect(() => {
 		if (id) {
-			const serverUtcOffHours = serverTimes.find(
-				(server) => server.Name === id,
-			)?.UTCOff;
-			if (serverUtcOffHours !== undefined) {
+			const serverUtcOffSeconds = serverTimes.find(
+				(server) => server.code === id,
+			)?.offsetSeconds;
+			if (serverUtcOffSeconds !== undefined) {
 				const timer = setInterval(() => {
 					// update blinking state of the colon
 					setBlinking((currentBlinking) => !currentBlinking);
 
 					// update the server date
 					const currentUnixTimestamp = Date.now();
-					const utcOffsetInMs = serverUtcOffHours * 60 * 60 * 1000;
+					const utcOffsetInMs = serverUtcOffSeconds * 1000;
 					const serverDate = new Date(currentUnixTimestamp + utcOffsetInMs);
 					setServerDate(serverDate);
 				}, 1000);

--- a/packages/map/components/WorldFlag.tsx
+++ b/packages/map/components/WorldFlag.tsx
@@ -1,0 +1,33 @@
+import { Box } from "@mantine/core";
+import type { FC } from "react";
+
+export const WorldFlag: FC = () => {
+	return (
+		<Box
+			className="me-e3e6c0b4"
+			style={{
+				"--flag-radius": "var(--mantine-radius-default)",
+				width: "calc(1.75rem * var(--mantine-scale))",
+			}}
+		>
+			<svg
+				xmlns="http://www.w3.org/2000/svg"
+				viewBox="0 0 28 21"
+				width="28"
+				height="21"
+			>
+				<title>International Flag of Planet Earth</title>
+				<rect width="28" height="21" fill="#0057b7" />
+				<g fill="none" stroke="#ffffff" strokeWidth="0.5">
+					<circle cx="14" cy="10.5" r="2.8" />
+					<circle cx="11.2" cy="7.7" r="2.8" />
+					<circle cx="16.8" cy="7.7" r="2.8" />
+					<circle cx="9" cy="10.5" r="2.8" />
+					<circle cx="19" cy="10.5" r="2.8" />
+					<circle cx="11.2" cy="13.3" r="2.8" />
+					<circle cx="16.8" cy="13.3" r="2.8" />
+				</g>
+			</svg>
+		</Box>
+	);
+};

--- a/packages/map/components/serverTimes.json
+++ b/packages/map/components/serverTimes.json
@@ -1,15 +1,7 @@
 [
 	{
 		"code": "fr1",
-		"offsetSeconds": 176398
-	},
-	{
-		"code": "en2",
-		"offsetSeconds": 165598
-	},
-	{
-		"code": "en1",
-		"offsetSeconds": 172796
+		"offsetSeconds": 3600
 	},
 	{
 		"code": "de2",
@@ -17,39 +9,47 @@
 	},
 	{
 		"code": "de1",
-		"offsetSeconds": 176397
+		"offsetSeconds": 3600
+	},
+	{
+		"code": "int2",
+		"offsetSeconds": -15548401
 	},
 	{
 		"code": "de3",
-		"offsetSeconds": -7783200
+		"offsetSeconds": -7783204
+	},
+	{
+		"code": "int1",
+		"offsetSeconds": 3600
 	},
 	{
 		"code": "int4",
-		"offsetSeconds": 0
+		"offsetSeconds": -7772400
 	},
 	{
 		"code": "pl1",
-		"offsetSeconds": -15570001
+		"offsetSeconds": -15570000
 	},
 	{
 		"code": "int3",
-		"offsetSeconds": 0
+		"offsetSeconds": -28801
 	},
 	{
 		"code": "int6",
-		"offsetSeconds": 0
+		"offsetSeconds": 28798
 	},
 	{
 		"code": "pl3",
-		"offsetSeconds": 176396
+		"offsetSeconds": 3600
 	},
 	{
 		"code": "int5",
-		"offsetSeconds": 0
+		"offsetSeconds": 3600
 	},
 	{
 		"code": "pl2",
-		"offsetSeconds": 176399
+		"offsetSeconds": 3600
 	},
 	{
 		"code": "pl4",
@@ -57,7 +57,7 @@
 	},
 	{
 		"code": "cz1",
-		"offsetSeconds": 176399
+		"offsetSeconds": 3600
 	},
 	{
 		"code": "int9",

--- a/packages/map/components/serverTimes.json
+++ b/packages/map/components/serverTimes.json
@@ -1,66 +1,66 @@
 [
 	{
-		"Name": "de2",
-		"UTCOff": -5
+		"code": "fr1",
+		"offsetSeconds": 176398
 	},
 	{
-		"Name": "en3",
-		"UTCOff": -6
+		"code": "en2",
+		"offsetSeconds": 165598
 	},
 	{
-		"Name": "en1",
-		"UTCOff": 0
+		"code": "en1",
+		"offsetSeconds": 172796
 	},
 	{
-		"Name": "cn1",
-		"UTCOff": 7
+		"code": "de2",
+		"offsetSeconds": -15570001
 	},
 	{
-		"Name": "ua1",
-		"UTCOff": 1
+		"code": "de1",
+		"offsetSeconds": 176397
 	},
 	{
-		"Name": "de3",
-		"UTCOff": -2
+		"code": "de3",
+		"offsetSeconds": -7783200
 	},
 	{
-		"Name": "pl3",
-		"UTCOff": 1
+		"code": "int4",
+		"offsetSeconds": 0
 	},
 	{
-		"Name": "pl2",
-		"UTCOff": 1
+		"code": "pl1",
+		"offsetSeconds": -15570001
 	},
 	{
-		"Name": "de1",
-		"UTCOff": 1
+		"code": "int3",
+		"offsetSeconds": 0
 	},
 	{
-		"Name": "pl4",
-		"UTCOff": -2
+		"code": "int6",
+		"offsetSeconds": 0
 	},
 	{
-		"Name": "cz1",
-		"UTCOff": 1
+		"code": "pl3",
+		"offsetSeconds": 176396
 	},
 	{
-		"Name": "en2",
-		"UTCOff": -2
+		"code": "int5",
+		"offsetSeconds": 0
 	},
 	{
-		"Name": "es1",
-		"UTCOff": 1
+		"code": "pl2",
+		"offsetSeconds": 176399
 	},
 	{
-		"Name": "eu3",
-		"UTCOff": 0
+		"code": "pl4",
+		"offsetSeconds": -7783200
 	},
 	{
-		"Name": "fr1",
-		"UTCOff": 1
+		"code": "cz1",
+		"offsetSeconds": 176399
 	},
 	{
-		"Name": "pl2",
-		"UTCOff": 1
+		"code": "int9",
+		"offsetSeconds": 0
 	}
 ]

--- a/packages/map/pages/index.tsx
+++ b/packages/map/pages/index.tsx
@@ -1,6 +1,7 @@
 import EUFlag from "@/components/EUFlag";
 import FavoriteStar from "@/components/FavoriteStar";
 import { TopNavigation } from "@/components/TopNavigation";
+import { WorldFlag } from "@/components/WorldFlag";
 import type { Server } from "@simrail/types";
 import Head from "next/head";
 import { type ComponentType, useEffect, useState } from "react";
@@ -90,7 +91,10 @@ export default function Home() {
 								/>
 								<span className="serverName">
 									<FlagIcon
-										code={server.ServerCode.slice(0, 2).toUpperCase()}
+										code={
+											server.ServerCode.match(/[A-Za-z]+/)?.at(0) ??
+											server.ServerCode.slice(0, 2)
+										}
 									/>
 									<span>{server.ServerName}</span>
 								</span>
@@ -118,6 +122,7 @@ export default function Home() {
 
         .serverName {
             margin-left: 32px;
+			margin-right: 16px;
             transition: all 200ms ease-in-out;
             display: flex;
             gap: 16px;
@@ -168,6 +173,10 @@ const FlagIcon = ({ code }: FlagIconProperties) => {
 					if (lang === "EN") lang = "GB";
 					if (lang === "EU") {
 						setComponent(() => EUFlag);
+						return;
+					}
+					if (lang === "INT") {
+						setComponent(() => WorldFlag);
 						return;
 					}
 


### PR DESCRIPTION
The top navigation shows the date and time on the server. However, some servers are not using the current date, e.g. de1 is 2 days ahead while de3 is still in october 2024. To actually display that the server timezone are no longer hours, but rather the offset seconds from UTC. This displays the time & date correctly.

DE1:
<img width="957" alt="image" src="https://github.com/user-attachments/assets/5fe763e0-938e-4163-897d-4cfe365bffa7" />

DE3:
<img width="869" alt="image" src="https://github.com/user-attachments/assets/14d86ba0-e59a-4567-8194-18026945b071" />
