### PR TITLE
add railcar EPO8-008 (added in patch 2025.02.11)

### DIFF
--- a/packages/map/components/railcars.json
+++ b/packages/map/components/railcars.json
@@ -588,6 +588,20 @@
 		"maxSpeed": 140
 	},
 	{
+		"id": "EP08-008",
+		"apiName": "4E/EP08-008",
+		"requiredDlcId": null,
+		"railcarType": "LOCOMOTIVE",
+		"typeIdentifier": "102E",
+		"designation": "EP08",
+		"producer": "Pafawag Wroclaw",
+		"yearsOfProduction": "1972-1976",
+		"weight": 80,
+		"length": 15.9,
+		"width": 3,
+		"maxSpeed": 140
+	},
+	{
 		"id": "EP08-013",
 		"apiName": "4E/EP08-013",
 		"requiredDlcId": null,


### PR DESCRIPTION
was added in yesterdays patch, doesn't differ from other EP08 railcars