### PR TITLE
handle different vehicle name layouts reported by api

### DIFF
--- a/packages/map/components/TrainText.tsx
+++ b/packages/map/components/TrainText.tsx
@@ -52,12 +52,21 @@ function extractVehicleInformation(
 	rawVehicleName: string,
 ): [string, number | null] {
 	if (rawVehicleName.includes(":")) {
-		// in case the name includes a ':' there is information about the load mass and brake regime included
-		// that we want to extract here. example: '424Z/424Z_brazowy:P:40@RandomContainerAll'
 		const vehicleNameParts = rawVehicleName.split(":");
-		const loadWeight = vehicleNameParts[2].split("@")[0];
-		return [vehicleNameParts[0], +loadWeight];
+		if (vehicleNameParts.length >= 3) {
+			// there is information about the load mass and brake regime included
+			// that we want to extract here. example: '424Z/424Z_brazowy:P:40@RandomContainerAll'
+			const loadWeight = vehicleNameParts[2].split("@")[0];
+			return [vehicleNameParts[0], +loadWeight];
+		}
+
+		if (vehicleNameParts.length === 2) {
+			// there is information about the vehicle type and brake regime included,
+			// but we only need the vehicle name in that case. example: '201E/ET22-256:G'
+			return [vehicleNameParts[0], null];
+		}
 	}
+
 	// raw vehicle name is just the name of the vehicle
 	return [rawVehicleName, null];
 }


### PR DESCRIPTION
Fixes an issue with a new vehicle name layout (used for example on int9), where locomotives will no longer include a trailing delimiter in their name (old: `4E/EU07-241:G:`. new: `4E/EU07-241:G`). This causes the `vehicleNameParts` array to not longer have 3 elements, which then causes the second split operation to fail (due to `vehicleNameParts[2]` being undefined).