### PR TITLE
Fix icon display issues with light/dark mode

### DIFF
--- a/packages/map/components/Markers/StationMarker.tsx
+++ b/packages/map/components/Markers/StationMarker.tsx
@@ -38,10 +38,7 @@ export const StationMarker = ({ station }: StationMarkerProps) => {
 	const { colorScheme } = useMantineColorScheme();
 
 	let botIcon = "/markers/icon-bot-simrail.jpg";
-	if (
-		colorScheme === "dark" ||
-		window.matchMedia("(prefers-color-scheme: dark)").matches
-	)
+	if (colorScheme === "dark")
 		botIcon = "/markers/icon-bot-simrail-dark.jpg";
 	// window.matchMedia('(prefers-color-scheme: dark)').matches incase colorScheme === auto we need to see what the system uses
 

--- a/packages/map/components/Markers/TrainMarker.tsx
+++ b/packages/map/components/Markers/TrainMarker.tsx
@@ -34,10 +34,7 @@ const TrainMarker = ({ train }: TrainMarkerProps) => {
 	const { colorScheme } = useMantineColorScheme();
 
 	let botIcon = "/markers/icon-bot-simrail.jpg";
-	if (
-		colorScheme === "dark" ||
-		window.matchMedia("(prefers-color-scheme: dark)").matches
-	)
+	if (colorScheme === "dark")
 		botIcon = "/markers/icon-bot-simrail-dark.jpg";
 	// window.matchMedia('(prefers-color-scheme: dark)').matches incase colorScheme === auto we need to see what the system uses
 


### PR DESCRIPTION
![problem.png](https://img.picui.cn/free/2025/04/13/67fbb128e384b.png)

In my Firefox Developer Edition, even when switched to light mode, the icon still stays in dark mode. 
This patch fixes this issue.