### PR TITLE
Added sneakpeeks and removed duplicate station

### DIFF
--- a/packages/map/components/sneakpeeks.json
+++ b/packages/map/components/sneakpeeks.json
@@ -58,5 +58,55 @@
 		"date": "2023-06-03",
 		"Latititude": 44.746798248605636,
 		"Longitude": -92.8478073210411
+	},
+	{
+		"title": "Pabianice Station",
+		"desc": "A few screenshots from the western extension of the DLC Łódź - Warsaw route - line no. 14.",
+		"url": "https://forum.simrail.eu/topic/7088-simrail-sneak-peek/page/2/#comment-36706",
+		"ImageURL": "https://s3.eu-central-1.amazonaws.com/forum.simrail.eu/monthly_2024_04/02_04.2024_1.png.de374c55b9fbc71546064d65a1d4fd07.png",
+		"Image2URL": "",
+		"date": "2024-04-02",
+		"Latititude": 51.660938059702055,
+		"Longitude": 19.32499058437774
+	},
+	{
+		"title": "Łódź Lublinek Station",
+		"desc": "A few screenshots from the western extension of the DLC Łódź - Warsaw route - line no. 14.",
+		"url": "https://forum.simrail.eu/topic/7088-simrail-sneak-peek/page/2/#comment-36706",
+		"ImageURL": "https://s3.eu-central-1.amazonaws.com/forum.simrail.eu/monthly_2024_04/02_04.2024_3.thumb.png.5e2cf4e376d0c6162ab7f41b1e2e207e.png",
+		"Image2URL": "https://s3.eu-central-1.amazonaws.com/forum.simrail.eu/monthly_2024_04/02_04.2024_4.thumb.png.9c4a40079b2f44161580d85c9b8b6892.png",
+		"date": "2024-04-02",
+		"Latititude": 51.71996101770606,
+		"Longitude": 19.357933295673476
+	},
+	{
+		"title": "Łódź Retkinia Station",
+		"desc": "A few screenshots from the western extension of the DLC Łódź - Warsaw route - line no. 14.",
+		"url": "https://forum.simrail.eu/topic/7088-simrail-sneak-peek/page/2/#comment-36706",
+		"ImageURL": "https://s3.eu-central-1.amazonaws.com/forum.simrail.eu/monthly_2024_04/02_04.2024_5.thumb.png.039563c9519c8e5b96f55ed96b360342.png",
+		"Image2URL": "https://s3.eu-central-1.amazonaws.com/forum.simrail.eu/monthly_2024_04/02_04.2024_6.png.9cfa53ed540293f9fa91aed050f56de4.png",
+		"date": "2024-04-02",
+		"Latititude": 51.74011099619081,
+		"Longitude": 19.40577361677488
+	},
+	{
+		"title": "Retkinia Signal Box",
+		"desc": "A few screenshots from the western extension of the DLC Łódź - Warsaw route - line no. 14.",
+		"url": "https://forum.simrail.eu/topic/7088-simrail-sneak-peek/page/2/#comment-36706",
+		"ImageURL": "https://s3.eu-central-1.amazonaws.com/forum.simrail.eu/monthly_2024_04/02_04.2024_7.thumb.png.1fef44ef15a1ca46d4b648fb05fd0ce7.png",
+		"Image2URL": "https://s3.eu-central-1.amazonaws.com/forum.simrail.eu/monthly_2024_04/02_04.2024_8.thumb.png.6f89a82145a781bb6ae2504c5d03ded5.png",
+		"date": "2024-04-02",
+		"Latititude": 51.74275548255224,
+		"Longitude": 19.41517266844793
+	},
+	{
+		"title": "Retkinia Signal Box Layout",
+		"desc": "Retkinia (Sorry for the squished image, press the title to see the original one)",
+		"url": "https://forum.simrail.eu/topic/8445-other-simrail-sneak-peek/#comment-33597",
+		"ImageURL": "https://s3.eu-central-1.amazonaws.com/forum.simrail.eu/monthly_2024_02/Retkinia_1.png.3d49ad38fe7d07c55fe9f88cbcc4ca1e.png",
+		"Image2URL": "",
+		"date": "2024-02-25",
+		"Latititude": 51.7429651015326,
+		"Longitude": 19.41499927691946
 	}
 ]

--- a/packages/map/components/stations.json
+++ b/packages/map/components/stations.json
@@ -552,18 +552,6 @@
 		"id": ""
 	},
 	{
-		"Name": "Łódź Olechów",
-		"Prefix": "",
-		"DifficultyLevel": 0,
-		"MainImageURL": "",
-		"AdditionalImage1URL": "",
-		"AdditionalImage2URL": "",
-		"DispatchedBy": [],
-		"Latititude": 51.731575,
-		"Longitude": 19.600367,
-		"id": ""
-	},
-	{
 		"Name": "Łódź Chojny",
 		"Prefix": "",
 		"DifficultyLevel": 0,


### PR DESCRIPTION
I somehow missed the the PR with edge stations contained a duplicate but it is now removed. I also thought that lodz DLC would cover all the sneakpeeks mentioned it but it seems to have been split up into another part, so added back those.