### PR TITLE
Fixes for if 'colorScheme' is auto

### DIFF
--- a/packages/map/components/Markers/StationMarker.tsx
+++ b/packages/map/components/Markers/StationMarker.tsx
@@ -38,9 +38,8 @@ export const StationMarker = ({ station }: StationMarkerProps) => {
 	const { colorScheme } = useMantineColorScheme();
 
 	let botIcon = "/markers/icon-bot-simrail.jpg";
-	if (colorScheme === "dark")
+	if (colorScheme === "dark" || colorScheme === "auto" && window.matchMedia('(prefers-color-scheme: dark)').matches)
 		botIcon = "/markers/icon-bot-simrail-dark.jpg";
-	// window.matchMedia('(prefers-color-scheme: dark)').matches incase colorScheme === auto we need to see what the system uses
 
 	const icon = L.icon({
 		iconUrl: station.DispatchedBy[0] && avatar ? avatar : botIcon,

--- a/packages/map/components/Markers/TrainMarker.tsx
+++ b/packages/map/components/Markers/TrainMarker.tsx
@@ -33,10 +33,10 @@ const TrainMarker = ({ train }: TrainMarkerProps) => {
 
 	const { colorScheme } = useMantineColorScheme();
 
+	
 	let botIcon = "/markers/icon-bot-simrail.jpg";
-	if (colorScheme === "dark")
+	if (colorScheme === "dark" || colorScheme === "auto" && window.matchMedia('(prefers-color-scheme: dark)').matches)
 		botIcon = "/markers/icon-bot-simrail-dark.jpg";
-	// window.matchMedia('(prefers-color-scheme: dark)').matches incase colorScheme === auto we need to see what the system uses
 
 	const icon = L.icon({
 		iconUrl: train.TrainData.ControlledBySteamID && avatar ? avatar : botIcon,


### PR DESCRIPTION
Before there were cases would theme could be dark but the bot icons would still be light, this is now fixed.