### PR TITLE
Improve dark mode icon logic and train speed display

### DIFF
--- a/packages/map/components/Markers/StationMarker.tsx
+++ b/packages/map/components/Markers/StationMarker.tsx
@@ -38,7 +38,11 @@ export const StationMarker = ({ station }: StationMarkerProps) => {
 	const { colorScheme } = useMantineColorScheme();
 
 	let botIcon = "/markers/icon-bot-simrail.jpg";
-	if (colorScheme === "dark" || colorScheme === "auto" && window.matchMedia('(prefers-color-scheme: dark)').matches)
+	if (
+		colorScheme === "dark" ||
+		(colorScheme === "auto" &&
+			window.matchMedia("(prefers-color-scheme: dark)").matches)
+	)
 		botIcon = "/markers/icon-bot-simrail-dark.jpg";
 
 	const icon = L.icon({

--- a/packages/map/components/Markers/TrainMarker.tsx
+++ b/packages/map/components/Markers/TrainMarker.tsx
@@ -33,9 +33,12 @@ const TrainMarker = ({ train }: TrainMarkerProps) => {
 
 	const { colorScheme } = useMantineColorScheme();
 
-	
 	let botIcon = "/markers/icon-bot-simrail.jpg";
-	if (colorScheme === "dark" || colorScheme === "auto" && window.matchMedia('(prefers-color-scheme: dark)').matches)
+	if (
+		colorScheme === "dark" ||
+		(colorScheme === "auto" &&
+			window.matchMedia("(prefers-color-scheme: dark)").matches)
+	)
 		botIcon = "/markers/icon-bot-simrail-dark.jpg";
 
 	const icon = L.icon({

--- a/packages/map/components/TrainText.tsx
+++ b/packages/map/components/TrainText.tsx
@@ -138,6 +138,8 @@ const TrainText = ({
 	// only the first unit is responsible for train traction at the moment, so this is just safe to assume // Not true anymore,-
 	// don't think it was true before update either as EMUs prob had multiple traction
 
+	const roundedSpeed = Math.round(train.TrainData.Velocity);
+
 	// however, this might be wrong in case the first unit is not yet registered in railcars.json, so we just
 	// fall back to displaying the raw api name in that case
 	const tractionUnit = locomotives.at(0);
@@ -242,8 +244,17 @@ const TrainText = ({
 			{!minified && <Title order={3}>Route </Title>}
 			{train.StartStation} - {train.EndStation}
 			<br />
-			Speed: {Math.round(train.TrainData.Velocity)} km/h
-			<br />
+			{roundedSpeed === 0 ? (
+				<>
+					Train currently stopped
+					<br />
+				</>
+			) : (
+				<>
+					Speed: {roundedSpeed} km/h
+					<br />
+				</>
+			)}
 			Vmax: {minMaxSpeed} km/h
 			<br />
 			{!minified && (


### PR DESCRIPTION
Refactored dark mode icon selection in StationMarker and TrainMarker for better readability. Updated TrainText to display 'Train currently stopped' when speed is zero, improving clarity for users.