### PR TITLE
Basic xbox support

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"fix": "biome check --fix"
 	},
 	"dependencies": {
-		"@simrail/types": "^0.0.4",
+		"@simrail/types": "^0.0.5",
 		"@types/node": "^20.17.10",
 		"@types/react": "18.0.26",
 		"@types/react-dom": "18.0.10",

--- a/packages/map/components/Markers/StationMarker.tsx
+++ b/packages/map/components/Markers/StationMarker.tsx
@@ -21,12 +21,18 @@ export const StationMarker = ({ station }: StationMarkerProps) => {
 	useEffect(() => {
 		async function getData() {
 			if (station.DispatchedBy[0]) {
-				const avatarRequest = await fetch(
-					`https://simrail-edr.emeraldnetwork.xyz/steam/${station.DispatchedBy[0].SteamId}`,
-				);
-				const profile: ProfileResponse = await avatarRequest.json();
-				setAvatar(profile.avatar);
-				setUsername(profile.personaname);
+				if (station.DispatchedBy[0].SteamId != "null") {
+					const avatarRequest = await fetch(
+						`https://simrail-edr.emeraldnetwork.xyz/steam/${station.DispatchedBy[0].SteamId}`,
+					);
+					const profile: ProfileResponse = await avatarRequest.json();
+					setAvatar(profile.avatar);
+					setUsername(profile.personaname);
+				}
+				if (station.DispatchedBy[0].XboxId != "null") {
+					setAvatar(null);
+					setUsername("Unknown [XBOX]");
+				}
 			} else {
 				setAvatar(null);
 				setUsername("BOT");

--- a/packages/map/components/SelectedTrainPopup.tsx
+++ b/packages/map/components/SelectedTrainPopup.tsx
@@ -28,7 +28,7 @@ const SelectedTrainPopup = () => {
 	// biome-ignore lint/correctness/useExhaustiveDependencies:
 	useEffect(() => {
 		if (selectedTrain)
-			getSteamProfileOrBot(selectedTrain.TrainData.ControlledBySteamID).then(
+			getSteamProfileOrBot(selectedTrain.TrainData.ControlledBySteamID).then( // support xbox players
 				// @ts-ignore
 				setData,
 			);

--- a/packages/map/components/SpotlightSearch.tsx
+++ b/packages/map/components/SpotlightSearch.tsx
@@ -59,11 +59,11 @@ export default function SpotlightSearch({
 		const platforms = [];
 		for (let i = 0; i < trains.length; i++) {
 			if (trains[i].Type === "user" && trains[i] != null) {
-				if (trains[i].TrainData.ControlledBySteamID != null) {
+				if (trains[i].TrainData.ControlledBySteamID != "null") {
 					userIDs.push(trains[i].TrainData.ControlledBySteamID);
 					platforms.push("steam");
 				}
-				if (trains[i].TrainData.ControlledByXboxID != null) {
+				else if (trains[i].TrainData.ControlledByXboxID != "null") {
 					userIDs.push(trains[i].TrainData.ControlledByXboxID);
 					platforms.push("xbox");
 				}
@@ -93,8 +93,7 @@ export default function SpotlightSearch({
 							usernamesCache.current.get(train.TrainData.ControlledBySteamID) ??
 							"Unknown";
 					}
-
-					if (train.TrainData.ControlledByXboxID) {
+					else if (train.TrainData.ControlledByXboxID) {
 						username = "Unknown [XBOX]" // make function for getting xbox usernames
 					}
 

--- a/packages/map/components/SpotlightSearch.tsx
+++ b/packages/map/components/SpotlightSearch.tsx
@@ -72,11 +72,11 @@ export default function SpotlightSearch({
 		for (let i = 0; i < stations.length; i++) {
 			if (stations[i].DispatchedBy[0] && stations[i].DispatchedBy[0].SteamId != null) {
 				userIDs.push(stations[i].DispatchedBy[0].SteamId);
-				platforms.push("steam")
+				platforms.push("steam");
 			}
 			if (stations[i].DispatchedBy[0] && stations[i].DispatchedBy[0].XboxId != null) {
 				userIDs.push(stations[i].DispatchedBy[0].XboxId);
-				platforms.push("xbox")
+				platforms.push("xbox");
 			}
 		}
 

--- a/packages/map/components/SpotlightSearch.tsx
+++ b/packages/map/components/SpotlightSearch.tsx
@@ -59,11 +59,11 @@ export default function SpotlightSearch({
 		const platforms = [];
 		for (let i = 0; i < trains.length; i++) {
 			if (trains[i].Type === "user" && trains[i] != null) {
-				if (trains[i].TrainData.ControlledBySteamID != "null") {
+				if (trains[i].TrainData.ControlledBySteamID) {
 					userIDs.push(trains[i].TrainData.ControlledBySteamID);
 					platforms.push("steam");
 				}
-				else if (trains[i].TrainData.ControlledByXboxID != "null") {
+				else if (trains[i].TrainData.ControlledByXboxID) {
 					userIDs.push(trains[i].TrainData.ControlledByXboxID);
 					platforms.push("xbox");
 				}

--- a/packages/map/components/serverTimes.json
+++ b/packages/map/components/serverTimes.json
@@ -62,5 +62,17 @@
 	{
 		"code": "int9",
 		"offsetSeconds": 0
+	},
+	{
+		"code": "xbx1",
+		"offsetSeconds": 0
+	},
+	{
+		"code": "xbx2",
+		"offsetSeconds": 0
+	},
+	{
+		"code": "xbx3",
+		"offsetSeconds": 0
 	}
 ]

--- a/packages/map/pages/index.tsx
+++ b/packages/map/pages/index.tsx
@@ -92,8 +92,16 @@ export default function Home() {
 								<span className="serverName">
 									<FlagIcon
 										code={
-											server.ServerCode.match(/[A-Za-z]+/)?.at(0) ??
-											server.ServerCode.slice(0, 2)
+											(() => {
+												const letters =
+													server.ServerCode.match(/[A-Za-z]+/)?.at(0) ??
+													server.ServerCode.slice(0, 2);
+												if (letters.toUpperCase() === "XBX") {
+													const numMatch = server.ServerCode.match(/^XBX(\d+)/i);
+													return numMatch ? `XBX${numMatch[1]}` : "XBX";
+												}
+												return letters;
+											})()
 										}
 									/>
 									<span>{server.ServerName}</span>
@@ -170,6 +178,10 @@ const FlagIcon = ({ code }: FlagIconProperties) => {
 					const flagPack = mod as unknown as FlagPackType;
 
 					let lang = code.toUpperCase();
+
+					if (lang === "XBX1") lang = "PL";
+					if (lang === "XBX2") lang = "INT";
+					if (lang === "XBX3") lang = "INT";
 					if (lang === "EN") lang = "GB";
 					if (lang === "EU") {
 						setComponent(() => EUFlag);


### PR DESCRIPTION
This makes the map not crash on xbox servers and supports their flags in the menu. Xbox users are shown as "Unknown [XBOX]" More can be done with the simrail user endpoint it seems, not tried it yet https://panel.simrail.eu:8084/users-open/[ID]. This does require the PR on simrail-types to be merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Xbox player support with platform-aware user handling and Xbox-specific display placeholders
  * Enhanced server flag/region resolution to recognize Xbox server codes and map them to appropriate flags

* **Chores**
  * Updated a package dependency version
  * Added new Xbox server configuration entries to the server list

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->