### PR TITLE
Show trains in border area in grey

### DIFF
--- a/packages/map/components/Markers/TrainMarker.tsx
+++ b/packages/map/components/Markers/TrainMarker.tsx
@@ -41,11 +41,12 @@ const TrainMarker = ({ train }: TrainMarkerProps) => {
 	)
 		botIcon = "/markers/icon-bot-simrail-dark.jpg";
 
+	const borderAreaClass = train.TrainData.InBorderStationArea ? ["in-border-area"] : [];
 	const icon = L.icon({
 		iconUrl: train.TrainData.ControlledBySteamID && avatar ? avatar : botIcon,
 		iconSize: [24, 24],
 		popupAnchor: [0, -12],
-		className: "steam-avatar",
+		className: ["steam-avatar", ...borderAreaClass].join(" "),
 	});
 
 	useMapEvents({

--- a/packages/map/styles/globals.css
+++ b/packages/map/styles/globals.css
@@ -51,6 +51,11 @@ a {
   z-index: 40;
 }
 
+.steam-avatar.in-border-area {
+  border-color: #929292;
+  filter: contrast(0.75);
+}
+
 .station-avatar {
   border: 2px solid #FF8A00;
   z-index: 50;


### PR DESCRIPTION
In order to make it easier to distinguish which trains can be driven and which are in the border area, show the avatar of trains in border area in grey colour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Train markers in border station areas now display with distinct visual styling, including updated border color and contrast adjustments, making them easily identifiable on the map.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->