### PR TITLE
Add satellite/OSM toggle to map

### DIFF
--- a/packages/map/components/Map.tsx
+++ b/packages/map/components/Map.tsx
@@ -15,6 +15,8 @@ import {
 	MdFullscreen,
 	MdFullscreenExit,
 	MdOutlineTraffic,
+	MdSatellite,
+	MdSatelliteAlt,
 	MdSpeakerNotes,
 	MdSpeakerNotesOff,
 	MdTraffic,
@@ -60,6 +62,11 @@ const LeaftletMap = ({ serverId }: MapProps) => {
 		defaultValue: true,
 	});
 
+	const [isSatellite, setIsSatellite] = useLocalStorage({
+		key: "isSatellite",
+		defaultValue: false,
+	});
+
 	const { toggle: toggleFullscreen, fullscreen } = useFullscreen();
 	const FullscreenIcon = fullscreen ? MdFullscreenExit : MdFullscreen;
 
@@ -67,6 +74,7 @@ const LeaftletMap = ({ serverId }: MapProps) => {
 		showSignalInfo === true ? MdTraffic : MdOutlineTraffic;
 	const RenderPopupIcon =
 		renderPopup === true ? MdSpeakerNotes : MdSpeakerNotesOff;
+	const SatelliteIcon = isSatellite === true ? MdSatellite : MdSatelliteAlt;
 
 	const { selectedTrain, setSelectedTrain } = useSelectedTrain();
 	const [stations, setStations] = useState<Station[] | null>(null);
@@ -239,6 +247,20 @@ const LeaftletMap = ({ serverId }: MapProps) => {
 						</Tooltip>
 
 						<Tooltip
+							label={
+								isSatellite ? "Switch to OSM view" : "Switch to satellite view"
+							}
+							position="right"
+						>
+							<button type="button" className={style.icon}>
+								<SatelliteIcon
+									onClick={() => setIsSatellite((prev) => !prev)}
+									size={24}
+								/>
+							</button>
+						</Tooltip>
+
+						<Tooltip
 							label={fullscreen ? "Exit fullscreen" : "Enter fullscreen"}
 							position="right"
 						>
@@ -249,11 +271,26 @@ const LeaftletMap = ({ serverId }: MapProps) => {
 					</div>
 				</Control>
 
-				<TileLayer
-					className={styles.test}
-					attribution='&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> | &copy; <a href="http://www.openrailwaymap.org/">OpenRailwayMap</a> | <a href = "https://discord.gg/d65Q8gWM5W" > Created by SimRail France 🇫🇷 Community </a>'
-					url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-				/>
+				{isSatellite ? (
+					<>
+						<TileLayer
+							attribution='Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGS, and the GIS User Community | &copy; <a href="http://www.openrailwaymap.org/">OpenRailwayMap</a> | <a href="https://discord.gg/d65Q8gWM5W">Created by SimRail France 🇫🇷 Community</a>'
+							url="https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"
+						/>
+						<TileLayer
+							url="https://{s}.tiles.openrailwaymap.org/standard/{z}/{x}/{y}.png"
+							opacity={0.6}
+							attribution='&copy; <a href="http://www.openrailwaymap.org/">OpenRailwayMap</a>'
+						/>
+					</>
+				) : (
+					<TileLayer
+						className={styles.test}
+						attribution='&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> | &copy; <a href="http://www.openrailwaymap.org/">OpenRailwayMap</a> | <a href="https://discord.gg/d65Q8gWM5W">Created by SimRail France 🇫🇷 Community</a>'
+						url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+					/>
+				)}
+
 				<LayersControl position="bottomright" collapsed={false}>
 					<LayersControl.Overlay
 						checked={


### PR DESCRIPTION
Introduce a satellite view toggle for the map.
Adds MdSatellite/MdSatelliteAlt imports, a persistent isSatellite state (useLocalStorage key "isSatellite"), and a control button (with tooltip) that switches the tile layers. When enabled, the map uses Esri World_Imagery tiles plus a semi-transparent OpenRailwayMap overlay; when disabled it falls back to the original OpenStreetMap + OpenRailwayMap attribution and tile.
Also introduces a SatelliteIcon computed from isSatellite and preserves existing controls and fullscreen behavior.

<img width="1878" height="923" alt="image" src="https://github.com/user-attachments/assets/0275d861-d419-4ebd-88fa-34ad2d6ccb77" />
<img width="1878" height="923" alt="image" src="https://github.com/user-attachments/assets/fa26c9d5-be94-4d61-84f9-7fd8d0442d9e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a map view toggle allowing users to switch between satellite and standard map views. User preference is automatically saved and restored in future sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->