### PR TITLE
Add unplayable stations and remote station for Łódź dlc

### DIFF
--- a/packages/map/components/stations.json
+++ b/packages/map/components/stations.json
@@ -516,18 +516,6 @@
 		"id": ""
 	},
 	{
-		"Name": "Słotwiny",
-		"Prefix": "",
-		"DifficultyLevel": 0,
-		"MainImageURL": "",
-		"AdditionalImage1URL": "",
-		"AdditionalImage2URL": "",
-		"DispatchedBy": [],
-		"Latititude": 51.72631,
-		"Longitude": 19.83242,
-		"id": ""
-	},
-	{
 		"Name": "Mikołajów",
 		"Prefix": "",
 		"DifficultyLevel": 0,
@@ -576,18 +564,6 @@
 		"id": ""
 	},
 	{
-		"Name": "Łódź Marysin",
-		"Prefix": "",
-		"DifficultyLevel": 0,
-		"MainImageURL": "",
-		"AdditionalImage1URL": "",
-		"AdditionalImage2URL": "",
-		"DispatchedBy": [],
-		"Latititude": 51.800168,
-		"Longitude": 19.486153,
-		"id": ""
-	},
-	{
 		"Name": "Puszcza Mariańska",
 		"Prefix": "",
 		"DifficultyLevel": 0,
@@ -609,6 +585,162 @@
 		"DispatchedBy": [],
 		"Latititude": 52.022929,
 		"Longitude": 20.035983,
+		"id": ""
+	},
+	{
+		"Name": "Piotrków Trybunalski",
+		"Prefix": "",
+		"DifficultyLevel": 0,
+		"MainImageURL": "",
+		"AdditionalImage1URL": "",
+		"AdditionalImage2URL": "",
+		"DispatchedBy": [],
+		"Latititude": 51.410472,
+		"Longitude": 19.684662,
+		"id": ""
+	},
+	{
+		"Name": "Rozprza",
+		"Prefix": "",
+		"DifficultyLevel": 0,
+		"MainImageURL": "",
+		"AdditionalImage1URL": "",
+		"AdditionalImage2URL": "",
+		"DispatchedBy": [],
+		"Latititude": 51.301530,
+		"Longitude": 19.660109,
+		"id": ""
+	},
+	{
+		"Name": "Bednary",
+		"Prefix": "",
+		"DifficultyLevel": 0,
+		"MainImageURL": "",
+		"AdditionalImage1URL": "",
+		"AdditionalImage2URL": "",
+		"DispatchedBy": [],
+		"Latititude": 52.105549,
+		"Longitude": 20.064796,
+		"id": ""
+	},
+	{
+		"Name": "Jackowice",
+		"Prefix": "",
+		"DifficultyLevel": 0,
+		"MainImageURL": "",
+		"AdditionalImage1URL": "",
+		"AdditionalImage2URL": "",
+		"DispatchedBy": [],
+		"Latititude": 52.156928,
+		"Longitude": 19.795845,
+		"id": ""
+	},
+	{
+		"Name": "Stara Wieś",
+		"Prefix": "",
+		"DifficultyLevel": 0,
+		"MainImageURL": "",
+		"AdditionalImage1URL": "",
+		"AdditionalImage2URL": "",
+		"DispatchedBy": [],
+		"Latititude": 52.227415,
+		"Longitude": 19.423632,
+		"id": ""
+	},
+	{
+		"Name": "Kutno",
+		"Prefix": "",
+		"DifficultyLevel": 0,
+		"MainImageURL": "",
+		"AdditionalImage1URL": "",
+		"AdditionalImage2URL": "",
+		"DispatchedBy": [],
+		"Latititude": 52.226998,
+		"Longitude": 19.346715,
+		"id": ""
+	},
+	{
+		"Name": "Florek",
+		"Prefix": "",
+		"DifficultyLevel": 0,
+		"MainImageURL": "",
+		"AdditionalImage1URL": "",
+		"AdditionalImage2URL": "",
+		"DispatchedBy": [],
+		"Latititude": 52.256806,
+		"Longitude": 19.318026,
+		"id": ""
+	},
+	{
+		"Name": "Ostrowy",
+		"Prefix": "",
+		"DifficultyLevel": 0,
+		"MainImageURL": "",
+		"AdditionalImage1URL": "",
+		"AdditionalImage2URL": "",
+		"DispatchedBy": [],
+		"Latititude": 52.298848,
+		"Longitude": 19.192289,
+		"id": ""
+	},
+	{
+		"Name": "Krzewie",
+		"Prefix": "",
+		"DifficultyLevel": 0,
+		"MainImageURL": "",
+		"AdditionalImage1URL": "",
+		"AdditionalImage2URL": "",
+		"DispatchedBy": [],
+		"Latititude": 52.235465,
+		"Longitude": 19.166905,
+		"id": ""
+	},
+	{
+		"Name": "Dionizów",
+		"Prefix": "",
+		"DifficultyLevel": 0,
+		"MainImageURL": "",
+		"AdditionalImage1URL": "",
+		"AdditionalImage2URL": "",
+		"DispatchedBy": [],
+		"Latititude": 51.623984,
+		"Longitude": 18.961630,
+		"id": ""
+	},
+	{
+		"Name": "Zduńska Wola Karsznice",
+		"Prefix": "",
+		"DifficultyLevel": 0,
+		"MainImageURL": "",
+		"AdditionalImage1URL": "",
+		"AdditionalImage2URL": "",
+		"DispatchedBy": [],
+		"Latititude": 51.589007,
+		"Longitude": 18.994707,
+		"id": ""
+	},
+	{
+		"Name": "Sieradz",
+		"Prefix": "",
+		"DifficultyLevel": 0,
+		"MainImageURL": "",
+		"AdditionalImage1URL": "",
+		"AdditionalImage2URL": "",
+		"DispatchedBy": [],
+		"Latititude": 51.628875,
+		"Longitude": 18.570001,
+		"id": ""
+	},
+	{
+		"Name": "Sędzice",
+		"Prefix": "",
+		"DifficultyLevel": 0,
+		"MainImageURL": "",
+		"AdditionalImage1URL": "",
+		"AdditionalImage2URL": "",
+		"DispatchedBy": [],
+		"Latititude": 51.628891,
+		"Longitude": 18.569990,
 		"id": ""
 	}
 ]

--- a/packages/map/components/stationsRemote.json
+++ b/packages/map/components/stationsRemote.json
@@ -84,6 +84,18 @@
 		"id": "Żyrardów"
 	},
 	{
+		"Name": "Słotwiny",
+		"Prefix": "",
+		"DifficultyLevel": 0,
+		"MainImageURL": "",
+		"AdditionalImage1URL": "",
+		"AdditionalImage2URL": "",
+		"DispatchedBy": [],
+		"Latititude": 51.726321,
+		"Longitude": 19.832398,
+		"id": "Żakowice Południowe"
+	},
+	{
 		"Name": "Łódź Andrzejów",
 		"Prefix": "",
 		"DifficultyLevel": 0,
@@ -94,5 +106,149 @@
 		"Latititude": 51.741028,
 		"Longitude": 19.617146,
 		"id": "Gałkówek"
+	},
+	{
+		"Name": "Łódź Dąbrowa PBSZ",
+		"Prefix": "",
+		"DifficultyLevel": 0,
+		"MainImageURL": "",
+		"AdditionalImage1URL": "",
+		"AdditionalImage2URL": "",
+		"DispatchedBy": [],
+		"Latititude": 51.749532,
+		"Longitude": 19.513492,
+		"id": "Łódź Widzew"
+	},
+	{
+		"Name": "Łódź Marysin",
+		"Prefix": "",
+		"DifficultyLevel": 0,
+		"MainImageURL": "",
+		"AdditionalImage1URL": "",
+		"AdditionalImage2URL": "",
+		"DispatchedBy": [],
+		"Latititude": 51.800167,
+		"Longitude": 19.486152,
+		"id": "Łódź Widzew"
+	},
+	{
+		"Name": "Dobroń APO",
+		"Prefix": "",
+		"DifficultyLevel": 0,
+		"MainImageURL": "",
+		"AdditionalImage1URL": "",
+		"AdditionalImage2URL": "",
+		"DispatchedBy": [],
+		"Latititude": 51.629363,
+		"Longitude": 19.240834,
+		"id": "Pabianice&Łask"
+	},
+	{
+		"Name": "Kolumna APO",
+		"Prefix": "",
+		"DifficultyLevel": 0,
+		"MainImageURL": "",
+		"AdditionalImage1URL": "",
+		"AdditionalImage2URL": "",
+		"DispatchedBy": [],
+		"Latititude": 51.614231,
+		"Longitude": 19.193488,
+		"id": "Pabianice&Łask"
+	},
+	{
+		"Name": "Borszewice APO",
+		"Prefix": "",
+		"DifficultyLevel": 0,
+		"MainImageURL": "",
+		"AdditionalImage1URL": "",
+		"AdditionalImage2URL": "",
+		"DispatchedBy": [],
+		"Latititude": 51.609461,
+		"Longitude": 19.039500,
+		"id": "Gajewniki&Łask"
+	},
+	{
+		"Name": "Męka APO",
+		"Prefix": "",
+		"DifficultyLevel": 0,
+		"MainImageURL": "",
+		"AdditionalImage1URL": "",
+		"AdditionalImage2URL": "",
+		"DispatchedBy": [],
+		"Latititude": 51.609401,
+		"Longitude": 18.787825,
+		"id": "Zduńska Wola"
+	},
+	{
+		"Name": "Zgierz Kontrewers",
+		"Prefix": "",
+		"DifficultyLevel": 0,
+		"MainImageURL": "",
+		"AdditionalImage1URL": "",
+		"AdditionalImage2URL": "",
+		"DispatchedBy": [],
+		"Latititude": 51.864796,
+		"Longitude": 19.340320,
+		"id": "Zigerz Północ"
+	},
+	{
+		"Name": "Chociszew",
+		"Prefix": "",
+		"DifficultyLevel": 0,
+		"MainImageURL": "",
+		"AdditionalImage1URL": "",
+		"AdditionalImage2URL": "",
+		"DispatchedBy": [],
+		"Latititude": 51.924110,
+		"Longitude": 19.266932,
+		"id": "Zigerz Północ"
+	},
+	{
+		"Name": "Ozorków",
+		"Prefix": "",
+		"DifficultyLevel": 0,
+		"MainImageURL": "",
+		"AdditionalImage1URL": "",
+		"AdditionalImage2URL": "",
+		"DispatchedBy": [],
+		"Latititude": 51.972469,
+		"Longitude": 19.266291,
+		"id": "Witonia"
+	},
+	{
+		"Name": "Łęczyca",
+		"Prefix": "",
+		"DifficultyLevel": 0,
+		"MainImageURL": "",
+		"AdditionalImage1URL": "",
+		"AdditionalImage2URL": "",
+		"DispatchedBy": [],
+		"Latititude": 52.049236,
+		"Longitude": 19.193252,
+		"id": "Witonia"
+	},
+	{
+		"Name": "Stryków",
+		"Prefix": "",
+		"DifficultyLevel": 0,
+		"MainImageURL": "",
+		"AdditionalImage1URL": "",
+		"AdditionalImage2URL": "",
+		"DispatchedBy": [],
+		"Latititude": 51.910582,
+		"Longitude": 19.593419,
+		"id": "Glinnik"
+	},
+	{
+		"Name": "Domaniewice",
+		"Prefix": "",
+		"DifficultyLevel": 0,
+		"MainImageURL": "",
+		"AdditionalImage1URL": "",
+		"AdditionalImage2URL": "",
+		"DispatchedBy": [],
+		"Latititude": 52.020445,
+		"Longitude": 19.821213,
+		"id": "Głowno"
 	}
 ]


### PR DESCRIPTION
Hello,
This update is include Łódź North Region DLC and Łódź Junction DLC's unplayable stations and remote station. I test it on my local server and no problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added several railway stations to the map, including locations near Puszcza Mariańska, Piotrków Trybunalski, Kutno, Sieradz, and Zduńska Wola.
  - Expanded remote station coverage with 14 additional stations and their geographic details.

- **Updates**
  - Updated the station dataset by removing Słotwiny and Łódź Marysin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->